### PR TITLE
Consistent formatting (create `.editorconfig`)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,109 @@
+#
+# https://docs.microsoft.com/en-us/visualstudio/ide/cpp-editorconfig-properties
+#
+
+root = true
+
+
+#####################
+### Core Settings ###
+#####################
+
+### All files ###
+
+[*]
+
+end_of_line              = crlf
+trim_trailing_whitespace = true
+insert_final_newline     = true
+
+### Code files ###
+
+[*.{c,c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
+
+indent_style             = tab
+indent_size              = 4
+tab_width                = 4
+
+# ### Other ###
+
+# [*.{xml,props,vcxproj,sln}]
+
+# indent_style             = tab
+# indent_size              = 2
+# tab_width                = 2
+
+
+###########
+### C++ ###
+###########
+
+[*.{c,c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
+
+charset = utf-8
+
+# Indentation preferences
+cpp_indent_braces                                   = false
+cpp_indent_multi_line_relative_to                   = innermost_parenthesis
+cpp_indent_within_parentheses                       = indent
+cpp_indent_preserve_within_parentheses              = true
+cpp_indent_case_contents                            = true
+cpp_indent_case_labels                              = false
+cpp_indent_case_contents_when_block                 = false
+cpp_indent_lambda_braces_when_parameter             = false
+cpp_indent_goto_labels                              = one_left
+cpp_indent_preprocessor                             = leftmost_column
+cpp_indent_access_specifiers                        = false
+cpp_indent_namespace_contents                       = false
+cpp_indent_preserve_comments                        = true
+
+# New line preferences
+cpp_new_line_before_open_brace_namespace            = new_line
+cpp_new_line_before_open_brace_type                 = ignore
+cpp_new_line_before_open_brace_function             = ignore
+cpp_new_line_before_open_brace_block                = ignore
+cpp_new_line_before_open_brace_lambda               = ignore
+cpp_new_line_scope_braces_on_separate_lines         = true
+cpp_new_line_close_brace_same_line_empty_type       = false
+cpp_new_line_close_brace_same_line_empty_function   = false
+cpp_new_line_before_catch                           = true
+cpp_new_line_before_else                            = true
+cpp_new_line_before_while_in_do_while               = true
+
+# Space preferences
+cpp_space_before_function_open_parenthesis          = remove
+cpp_space_within_parameter_list_parentheses         = false
+cpp_space_between_empty_parameter_list_parentheses  = false
+cpp_space_after_keywords_in_control_flow_statements = true
+cpp_space_within_control_flow_statement_parentheses = false
+cpp_space_before_lambda_open_parenthesis            = false
+cpp_space_within_cast_parentheses                   = false
+cpp_space_after_cast_close_parenthesis              = false
+cpp_space_within_expression_parentheses             = false
+cpp_space_before_block_open_brace                   = false
+cpp_space_between_empty_braces                      = false
+cpp_space_before_initializer_list_open_brace        = false
+cpp_space_within_initializer_list_braces            = true
+cpp_space_preserve_in_initializer_list              = true
+cpp_space_before_open_square_bracket                = false
+cpp_space_within_square_brackets                    = false
+cpp_space_before_empty_square_brackets              = false
+cpp_space_between_empty_square_brackets             = false
+cpp_space_group_square_brackets                     = true
+cpp_space_within_lambda_brackets                    = false
+cpp_space_between_empty_lambda_brackets             = false
+cpp_space_before_comma                              = false
+cpp_space_after_comma                               = true
+cpp_space_remove_around_member_operators            = true
+cpp_space_before_inheritance_colon                  = false
+cpp_space_before_constructor_colon                  = false
+cpp_space_remove_before_semicolon                   = true
+cpp_space_after_semicolon                           = true
+cpp_space_remove_around_unary_operator              = true
+cpp_space_around_binary_operator                    = ignore
+cpp_space_around_assignment_operator                = ignore
+cpp_space_pointer_reference_alignment               = ignore
+cpp_space_around_ternary_operator                   = insert
+
+# Wrapping preferences
+cpp_wrap_preserve_blocks                            = all_one_line_scopes

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+#####################
+### Visual Studio ###
+#####################
+
+## User-specific files ##
+*.vcxitems.user
+*.vcxproj.user
+*.suo
+
+## Visual Studio 2015/2017 cache/options directory ##
+.vs/
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb

--- a/algorithm.h
+++ b/algorithm.h
@@ -13,7 +13,7 @@ namespace rde
 template <typename T, typename... Args> RDE_FORCEINLINE
 void construct_args(T* p, Args&&... args)
 {
-    ::new (static_cast<void*>(p)) T(std::forward<Args>(args)...);
+	::new (static_cast<void*>(p)) T(std::forward<Args>(args)...);
 }
 
 //-----------------------------------------------------------------------------
@@ -64,15 +64,15 @@ void copy_construct_n(T* first, size_t n, T* result)
 template <typename T>
 void move_construct_n(T* first, size_t n, T* result)
 {
-    internal::move_construct_n(first, n, result, int_to_type<has_trivial_copy<T>::value>());
+	internal::move_construct_n(first, n, result, int_to_type<has_trivial_copy<T>::value>());
 }
- 
+
 //-----------------------------------------------------------------------------
 template<typename T>
 void move_n(const T* from, size_t n, T* result)
 {
 	RDE_ASSERT(from != result || n == 0);
-	// Overlap? 
+	// Overlap?
 	if (result + n >= from && result < from + n)
 	{
 		internal::move_n(from, n, result, int_to_type<has_trivial_copy<T>::value>());
@@ -252,7 +252,7 @@ RDE_FORCEINLINE short abs(short x)
 template<typename T> inline
 T max(const T& x, const T& y)
 {
-    return x > y ? x : y;
+	return x > y ? x : y;
 }
 
 //-----------------------------------------------------------------------------
@@ -290,4 +290,3 @@ void swap(TAssignable& a, TAssignable& b)
 
 //-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_ALGORITHM_H
-

--- a/alignment.h
+++ b/alignment.h
@@ -11,34 +11,38 @@ namespace internal
 #pragma warning(push)
 // structure was padded due to __declspec(align())
 #pragma warning(disable: 4324)
-	template<typename T>
-	struct alignof_helper
-	{
-		char	x;
-		T		y;
-	};
+
+template<typename T>
+struct alignof_helper
+{
+	char	x;
+	T		y;
+};
+
 #ifdef _MSC_VER
-	__declspec(align(16)) struct aligned16 { uint64 member[2]; };
+__declspec(align(16)) struct aligned16 { uint64 member[2]; };
 #else
-    struct __attribute__ ((aligned (16))) aligned16 { uint64 member[2]; } ;
+struct __attribute__((aligned(16))) aligned16 { uint64 member[2]; };
 #endif
-    
+
 #pragma warning(pop)
-	template<size_t N> struct type_with_alignment
-	{
-		typedef char err_invalid_alignment[N > 0 ? -1 : 1];
-	};
-	template<> struct type_with_alignment<0> {};
-	template<> struct type_with_alignment<1> { uint8 member; };
-	template<> struct type_with_alignment<2> { uint16 member; };
-	template<> struct type_with_alignment<4> { uint32 member; };
-	template<> struct type_with_alignment<8> { uint64 member; };
-	template<> struct type_with_alignment<16> { aligned16 member; };
-}
+
+template<size_t N> struct type_with_alignment
+{
+	typedef char err_invalid_alignment[N > 0 ? -1 : 1];
+};
+template<> struct type_with_alignment<0> {};
+template<> struct type_with_alignment<1> { uint8 member; };
+template<> struct type_with_alignment<2> { uint16 member; };
+template<> struct type_with_alignment<4> { uint32 member; };
+template<> struct type_with_alignment<8> { uint64 member; };
+template<> struct type_with_alignment<16> { aligned16 member; };
+} // namespace internal
+
 template<typename T>
 struct rde_alignof
 {
-	enum 
+	enum
 	{
 		res = offsetof(internal::alignof_helper<T>, y)
 	};
@@ -49,6 +53,7 @@ struct aligned_as
 	typedef typename internal::type_with_alignment<rde_alignof<T>::res> res;
 };
 
-}
+} // namespace rde
 
-#endif
+//-----------------------------------------------------------------------------
+#endif // #ifndef RDESTL_ALIGNMENT_H

--- a/allocator.cpp
+++ b/allocator.cpp
@@ -6,4 +6,4 @@ const char* allocator::get_name() const
 {
 	return m_name;
 }
-} // rde
+} // namespace rde

--- a/allocator.h
+++ b/allocator.h
@@ -3,17 +3,16 @@
 
 namespace rde
 {
-
 // CONCEPT!
 class allocator
 {
 public:
-	explicit allocator(const char* name = "DEFAULT"):	m_name(name) {}
-    allocator(const allocator&) = default;
-    allocator(allocator&&) = default;
+	explicit allocator(const char* name = "DEFAULT"): m_name(name) {}
+	allocator(const allocator&) = default;
+	allocator(allocator&&) = default;
 	~allocator() {}
 
-    allocator& operator=(const allocator&) = default;
+	allocator& operator=(const allocator&) = default;
 
 	void* allocate(unsigned int bytes, int flags = 0);
 	// Not supported for standard allocator for the time being.

--- a/basic_string.h
+++ b/basic_string.h
@@ -14,41 +14,41 @@ namespace rde
 //=============================================================================
 // @note: this one is totally _not_ std::string compatible for the time being!
 // one way conversion should work, ie rde --> STL.
-template<typename E, 
+template<typename E,
 	class TAllocator = rde::allocator,
 	typename TStorage = rde::simple_string_storage<E, TAllocator> >
-class basic_string : private TStorage
+	class basic_string: private TStorage
 {
 public:
 	typedef typename TStorage::value_type		value_type;
 	typedef typename TStorage::size_type		size_type;
 	typedef typename TStorage::const_iterator	const_iterator;
 	typedef typename TStorage::allocator_type	allocator_type;
-    
-    //For find
-    static const size_type npos = size_type(-1);
-    
+
+	//For find
+	static const size_type npos = size_type(-1);
+
 	explicit basic_string(const allocator_type& allocator = allocator_type())
-	:	TStorage(allocator)
+		: TStorage(allocator)
 	{
 		/**/
 	}
 	// yeah, EXPLICIT.
-	explicit basic_string(const value_type* str, 
+	explicit basic_string(const value_type* str,
 		const allocator_type& allocator = allocator_type())
-	:	TStorage(str, allocator)
+		: TStorage(str, allocator)
 	{
 		/**/
 	}
-	basic_string(const value_type* str, size_type len, 
+	basic_string(const value_type* str, size_type len,
 		const allocator_type& allocator = allocator_type())
-	:	TStorage(str, len, allocator)
+		: TStorage(str, len, allocator)
 	{
 		/**/
 	}
-	basic_string(const basic_string& str, 
+	basic_string(const basic_string& str,
 		const allocator_type& allocator = allocator_type())
-	:	TStorage(str, allocator)
+		: TStorage(str, allocator)
 	{
 		/**/
 	}
@@ -56,8 +56,8 @@ public:
 	{
 		/**/
 	}
-    
-    size_type capacity() const { return TStorage::capacity(); }
+
+	size_type capacity() const { return TStorage::capacity(); }
 
 	// No operator returning ref for the time being. It's dangerous with COW.
 	value_type operator[](size_type i) const
@@ -71,7 +71,7 @@ public:
 	{
 		RDE_ASSERT(rhs.invariant());
 		if (this != &rhs) {
-            TStorage::operator=((TStorage&)rhs);
+			TStorage::operator=((TStorage&)rhs);
 		}
 		RDE_ASSERT(invariant());
 		return *this;
@@ -104,8 +104,8 @@ public:
 
 	void append(const value_type* str, size_type len)
 	{
-        if( !str || len == 0 || *str == 0 )
-            return;
+		if (!str || len == 0 || *str == 0)
+			return;
 		TStorage::append(str, len);
 	}
 	void append(const basic_string& str)
@@ -192,7 +192,7 @@ public:
 		for (size_type i = 0; i < len; ++i)
 		{
 			if (data[i] < 'a')
-				data[i] += chDelta;		
+				data[i] += chDelta;
 		}
 	}
 	void make_upper()
@@ -239,65 +239,65 @@ public:
 		}
 		return retIndex;
 	}
-    
-    size_type find(const value_type* needle) const
-    {       
-        const value_type* s(c_str());    
-        size_type si(0);
-        while(*s)
-        {
-            const value_type* n = needle;
-            if( *s == *n ) //first character matches
-            {
-                //go through the sequence, and make sure while(x) x == n for all of n
-                const value_type* x = s; 
-                size_type match = 0;
-                while(*x && *n) 
-                {
-                    if( *n == *x )
-                        ++match;
-                    ++n;
-                    ++x;
-                }
-                if( match == strlen(needle) )
-                    return si;
-            }
-            ++s;
-            ++si;
-        }
-        return basic_string::npos;
-    }
-    
-    size_type rfind(const value_type* needle) const
-    {   
-		const value_type* s(c_str() + length());
-		size_type si(length()+1); 
 
-		//find the last index of the first char in needle
-		//searching from end->start for obvious reasons
-		while(--si >= 0) 
+	size_type find(const value_type* needle) const
+	{
+		const value_type* s(c_str());
+		size_type si(0);
+		while (*s)
 		{
-			//if the first character matches, run our check
-			if( *s-- == *needle ) {
-
+			const value_type* n = needle;
+			if (*s == *n) //first character matches
+			{
 				//go through the sequence, and make sure while(x) x == n for all of n
-				const value_type* x = c_str() + si; 
-				const value_type* n = needle;
+				const value_type* x = s;
 				size_type match = 0;
-				while(*x && *n) 
+				while (*x && *n)
 				{
-					if( *n == *x )
+					if (*n == *x)
 						++match;
 					++n;
 					++x;
 				}
-				if( match == strlen(needle) )
+				if (match == strlen(needle))
+					return si;
+			}
+			++s;
+			++si;
+		}
+		return basic_string::npos;
+	}
+
+	size_type rfind(const value_type* needle) const
+	{
+		const value_type* s(c_str() + length());
+		size_type si(length()+1);
+
+		//find the last index of the first char in needle
+		//searching from end->start for obvious reasons
+		while (--si >= 0)
+		{
+			//if the first character matches, run our check
+			if (*s-- == *needle) {
+
+				//go through the sequence, and make sure while(x) x == n for all of n
+				const value_type* x = c_str() + si;
+				const value_type* n = needle;
+				size_type match = 0;
+				while (*x && *n)
+				{
+					if (*n == *x)
+						++match;
+					++n;
+					++x;
+				}
+				if (match == strlen(needle))
 					return si;
 			}
 		}
 		return basic_string::npos;
-    }
-    
+	}
+
 private:
 	bool invariant() const
 	{
@@ -307,7 +307,7 @@ private:
 
 //-----------------------------------------------------------------------------
 template<typename E, class TStorage, class TAllocator>
-bool operator==(const basic_string<E, TStorage, TAllocator>& lhs, 
+bool operator==(const basic_string<E, TStorage, TAllocator>& lhs,
 				const basic_string<E, TStorage, TAllocator>& rhs)
 {
 	return lhs.compare(rhs) == 0;
@@ -315,7 +315,7 @@ bool operator==(const basic_string<E, TStorage, TAllocator>& lhs,
 
 //-----------------------------------------------------------------------------
 template<typename E, class TStorage, class TAllocator>
-bool operator!=(const basic_string<E, TStorage, TAllocator>& lhs, 
+bool operator!=(const basic_string<E, TStorage, TAllocator>& lhs,
 				const basic_string<E, TStorage, TAllocator>& rhs)
 {
 	return !(lhs == rhs);
@@ -323,7 +323,7 @@ bool operator!=(const basic_string<E, TStorage, TAllocator>& lhs,
 
 //-----------------------------------------------------------------------------
 template<typename E, class TStorage, class TAllocator>
-bool operator<(const basic_string<E, TStorage, TAllocator>& lhs, 
+bool operator<(const basic_string<E, TStorage, TAllocator>& lhs,
 				const basic_string<E, TStorage, TAllocator>& rhs)
 {
 	return lhs.compare(rhs) < 0;
@@ -331,7 +331,7 @@ bool operator<(const basic_string<E, TStorage, TAllocator>& lhs,
 
 //-----------------------------------------------------------------------------
 template<typename E, class TStorage, class TAllocator>
-bool operator>(const basic_string<E, TStorage, TAllocator>& lhs, 
+bool operator>(const basic_string<E, TStorage, TAllocator>& lhs,
 				const basic_string<E, TStorage, TAllocator>& rhs)
 {
 	return lhs.compare(rhs) > 0;

--- a/buffer_allocator.h
+++ b/buffer_allocator.h
@@ -5,14 +5,13 @@
 
 namespace rde
 {
-
 // CONCEPT!
 class buffer_allocator
 {
 public:
 	explicit buffer_allocator(const char* name, char* mem,
 		size_t bufferSize)
-	:	m_name(name), 
+		: m_name(name),
 		m_buffer(mem),
 		m_bufferTop(0),
 		m_bufferSize(bufferSize)
@@ -43,5 +42,6 @@ private:
 };
 
 } // namespace rde
+
 //-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_BUFFER_ALLOCATOR_H

--- a/cow_string_storage.h
+++ b/cow_string_storage.h
@@ -36,35 +36,35 @@ public:
 	typedef int					size_type;
 	typedef TAllocator			allocator_type;
 	typedef const value_type*	const_iterator;
-	static const unsigned long	kGranularity = 32;	
+	static const unsigned long	kGranularity = 32;
 
 	explicit cow_string_storage(const allocator_type& allocator)
-	:	m_allocator(allocator)
+		: m_allocator(allocator)
 	{
 		construct_string(0);
 	}
 	cow_string_storage(const value_type* str, const allocator_type& allocator)
-	:	m_allocator(allocator)
+		: m_allocator(allocator)
 	{
 		const int len = strlen(str);
 		construct_string(len);
-		Sys::MemCpy(m_data, str, len*sizeof(value_type));
+		Sys::MemCpy(m_data, str, len * sizeof(value_type));
 		RDE_ASSERT(len < string_rep::kMaxCapacity);
 		get_rep()->size = static_cast<short>(len);
 		m_data[len] = 0;
 	}
-	cow_string_storage(const value_type* str, size_type len, 
+	cow_string_storage(const value_type* str, size_type len,
 		const allocator_type& allocator)
-	:	m_allocator(allocator)
+		: m_allocator(allocator)
 	{
 		construct_string(len);
-		Sys::MemCpy(m_data, str, len*sizeof(value_type));
+		Sys::MemCpy(m_data, str, len * sizeof(value_type));
 		RDE_ASSERT(len < string_rep::kMaxCapacity);
 		get_rep()->size = static_cast<short>(len);
 		m_data[len] = 0;
 	}
 	cow_string_storage(const cow_string_storage& rhs, const allocator_type& allocator)
-	:	m_data(rhs.m_data),
+		: m_data(rhs.m_data),
 		m_allocator(allocator)
 	{
 		if (rhs.is_dynamic())
@@ -75,7 +75,7 @@ public:
 		{
 			const int len = rhs.length();
 			construct_string(len);
-			Sys::MemCpy(m_data, rhs.c_str(), len*sizeof(value_type));
+			Sys::MemCpy(m_data, rhs.c_str(), len * sizeof(value_type));
 			RDE_ASSERT(len < string_rep::kMaxCapacity);
 			get_rep()->size = static_cast<short>(len);
 			m_data[len] = 0;
@@ -106,7 +106,7 @@ public:
 		RDE_ASSERT(str != m_data);
 		release_string();
 		construct_string(len);
-		Sys::MemCpy(m_data, str, len*sizeof(value_type));
+		Sys::MemCpy(m_data, str, len * sizeof(value_type));
 		get_rep()->size = short(len);
 		m_data[len] = 0;
 	}
@@ -171,7 +171,7 @@ protected:
 		if (capacity_hint != 0)
 		{
 			++capacity_hint;
-			capacity_hint = (capacity_hint+kGranularity-1) & ~(kGranularity-1);
+			capacity_hint = (capacity_hint + kGranularity - 1) & ~(kGranularity - 1);
 			if (capacity_hint < kGranularity)
 				capacity_hint = kGranularity;
 		}
@@ -182,12 +182,12 @@ protected:
 		{
 			if (capacity_hint > 0)
 			{
-				const size_type toAlloc = sizeof(string_rep) + sizeof(value_type)*capacity_hint;
+				const size_type toAlloc = sizeof(string_rep) + sizeof(value_type) * capacity_hint;
 				void* newMem = m_allocator.allocate(toAlloc);
 				string_rep* newRep = reinterpret_cast<string_rep*>(newMem);
 				newRep->init(short(capacity_hint));
 				value_type* newData = reinterpret_cast<value_type*>(newRep + 1);
-				Sys::MemCpy(newData, m_data, rep->size*sizeof(value_type));
+				Sys::MemCpy(newData, m_data, rep->size * sizeof(value_type));
 				newRep->size = rep->size;
 				newData[rep->size] = 0;
 				release_string();
@@ -215,12 +215,12 @@ private:
 		if (capacity != 0)
 		{
 			++capacity;
-			capacity = (capacity+kGranularity-1) & ~(kGranularity-1);
+			capacity = (capacity + kGranularity - 1) & ~(kGranularity - 1);
 			if (capacity < kGranularity)
 				capacity = kGranularity;
 			RDE_ASSERT(capacity < string_rep::kMaxCapacity);
 
-			const size_type toAlloc = sizeof(string_rep) + sizeof(value_type)*capacity;
+			const size_type toAlloc = sizeof(string_rep) + sizeof(value_type) * capacity;
 			void* mem = m_allocator.allocate(toAlloc);
 			string_rep* rep = reinterpret_cast<string_rep*>(mem);
 			rep->init(static_cast<short>(capacity));
@@ -252,10 +252,11 @@ private:
 	E*			m_data;
 	// @note: hack-ish. sizeof(string_rep) bytes for string_rep, than place for terminating
 	// character (up to 2-bytes!)
-	char		m_buffer[sizeof(string_rep)+2]; 
+	char		m_buffer[sizeof(string_rep) + 2];
 	TAllocator	m_allocator;
 };
 
-} // rde
+} // namespace rde
 
+//-----------------------------------------------------------------------------
 #endif // RDESTL_COW_STRING_STORAGE_H

--- a/fixed_array.h
+++ b/fixed_array.h
@@ -16,7 +16,7 @@ public:
 	typedef const T*	const_iterator;
 	typedef size_t		size_type;
 
-	fixed_array() {/**/}
+	fixed_array() { /**/ }
 	fixed_array(const T array[N])
 	{
 		rde::copy_n(&array[0], N, m_data);
@@ -28,14 +28,14 @@ public:
 	const_iterator begin() const	{ return &m_data[0]; }
 	iterator end()					{ return begin() + N; }
 	const_iterator end() const		{ return begin() + N; }
-	size_type size() const	{ return N; }
-	T* data()				{ return &m_data[0]; }
-	const T* data() const	{ return &m_data[0]; }
+	size_type size() const			{ return N; }
+	T* data()						{ return &m_data[0]; }
+	const T* data() const			{ return &m_data[0]; }
 
-	const T& front() const	{ return *begin(); }
-	T& front()				{ return *begin(); }
-	const T& back() const	{ return *(end() - 1); }
-	T& back()				{ return *(end() - 1); }
+	T& front()						{ return *begin(); }
+	const T& front() const			{ return *begin(); }
+	T& back()						{ return *(end() - 1); }
+	const T& back() const			{ return *(end() - 1); }
 
 	RDE_FORCEINLINE T& operator[](size_type i)
 	{
@@ -52,8 +52,7 @@ private:
 	T	m_data[N];
 };
 
-} // rde
+} // namespace rde
 
 //-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_FIXED_ARRAY_H
-

--- a/fixed_list.h
+++ b/fixed_list.h
@@ -8,7 +8,6 @@
 
 namespace rde
 {
-
 template<typename T, size_t TCapacity>
 class fixed_list
 {
@@ -30,7 +29,7 @@ class fixed_list
 		typedef unsigned long	index_type;
 	};
 
-	enum { select = TCapacity+1 > 255 ? (TCapacity+1 > 65535 ? 2 : 1) : 0 };
+	enum { select = TCapacity + 1 > 255 ? (TCapacity + 1 > 65535 ? 2 : 1) : 0 };
 	typedef type_selector<select>	index_type_selector;
 
 public:
@@ -60,10 +59,10 @@ private:
 		typedef bidirectional_iterator_tag	iterator_category;
 
 		explicit node_iterator(TNodePtr node, const fixed_list* list)
-		:	m_node(node), m_list(list) {/**/}
+			: m_node(node), m_list(list) { /**/ }
 		template<typename UNodePtr, typename UPtr, typename URef>
 		node_iterator(const node_iterator<UNodePtr, UPtr, URef>& rhs)
-		:	m_node(rhs.node()),
+			: m_node(rhs.node()),
 			m_list(rhs.list())
 		{
 			/**/
@@ -131,7 +130,7 @@ public:
 	typedef node_iterator<const node*, const T*, const T&>	const_iterator;
 
 	fixed_list()
-	:	m_num_nodes(0)
+		: m_num_nodes(0)
 	{
 		init_free_indices();
 		get_root()->reset();
@@ -145,7 +144,7 @@ public:
 	fixed_list(const fixed_list& rhs)
 	{
 		get_root()->reset();
-		copy(rhs, 
+		copy(rhs,
 			int_to_type<has_trivial_copy<T>::value>());
 	}
 	explicit fixed_list(e_noinitialize)
@@ -161,7 +160,7 @@ public:
 	{
 		if (this != &rhs)
 		{
-			copy(rhs, 
+			copy(rhs,
 				int_to_type<has_trivial_copy<T>::value>());
 		}
 		return *this;
@@ -172,10 +171,10 @@ public:
 	iterator end()					{ return iterator(get_root(), this); }
 	const_iterator end() const		{ return const_iterator(get_root(), this); }
 
-	const T& front() const	{ RDE_ASSERT(!empty()); return get_next(get_root())->value; }
-	T& front()				{ RDE_ASSERT(!empty()); return get_next(get_root())->value; }
-	const T& back() const	{ RDE_ASSERT(!empty()); return get_prev(get_root())->value; }
-	T& back()				{ RDE_ASSERT(!empty()); return get_prev(get_root())->value; }
+	T& front()						{ RDE_ASSERT(!empty()); return get_next(get_root())->value; }
+	const T& front() const			{ RDE_ASSERT(!empty()); return get_next(get_root())->value; }
+	T& back()						{ RDE_ASSERT(!empty()); return get_prev(get_root())->value; }
+	const T& back() const			{ RDE_ASSERT(!empty()); return get_prev(get_root())->value; }
 
 	void push_front(const T& value)
 	{
@@ -249,7 +248,7 @@ public:
 	}
 
 	template<class InputIterator>
-	void assign(InputIterator first, InputIterator last) 
+	void assign(InputIterator first, InputIterator last)
 	{
 		clear();
 		while (first != last)
@@ -347,6 +346,7 @@ private:
 	size_type		m_num_nodes;	// Excluding root!
 };
 
-}
+} // namespace rde
 
-#endif
+//-----------------------------------------------------------------------------
+#endif // #ifndef RDESTL_FIXED_LIST_H

--- a/fixed_sorted_vector.h
+++ b/fixed_sorted_vector.h
@@ -6,23 +6,26 @@
 
 namespace rde
 {
-template<typename TKey, typename TValue, 
-	int TCapacity, bool TGrowOnOverflow, class TCompare = rde::less<TKey>,
-	class TAllocator = rde::allocator>
-class fixed_sorted_vector : public sorted_vector<TKey, TValue, TCompare,
-	TAllocator,
-	fixed_vector_storage<pair<TKey, TValue>, TAllocator, TCapacity, 
-		TGrowOnOverflow> >
+template<
+	typename TKey, typename TValue, int TCapacity, bool TGrowOnOverflow,
+	class TCompare = rde::less<TKey>,
+	class TAllocator = rde::allocator
+>
+class fixed_sorted_vector: public sorted_vector<
+	TKey, TValue, TCompare, TAllocator, fixed_vector_storage<
+	pair<TKey, TValue>, TAllocator, TCapacity, TGrowOnOverflow
+	>
+>
 {
 public:
 	explicit fixed_sorted_vector(const allocator_type& allocator = allocator_type())
-	:	sorted_vector(allocator)
+		: sorted_vector(allocator)
 	{
 		/**/
 	}
 };
 
-} // rde
+} // namespace rde
 
+//-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_FIXED_SORTED_VECTOR_H
-

--- a/fixed_substring.h
+++ b/fixed_substring.h
@@ -10,7 +10,7 @@ namespace rde
 // Cannot grow.
 // Never allocates memory.
 template<typename E, size_t N>
-class fixed_substring : private fixed_array<E, N + 1>
+class fixed_substring: private fixed_array<E, N + 1>
 {
 	typedef fixed_array<E, N + 1>	Base;
 public:
@@ -142,6 +142,7 @@ public:
 	}
 };
 
-} // rde
+} // namespace rde
 
+//-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_FIXED_SUBSTRING_H

--- a/fixed_vector.h
+++ b/fixed_vector.h
@@ -15,10 +15,10 @@ namespace rde
 {
 //=============================================================================
 template<typename T, class TAllocator, int TCapacity, bool TGrowOnOverflow>
-struct fixed_vector_storage 
+struct fixed_vector_storage
 {
 	explicit fixed_vector_storage(const TAllocator& allocator)
-	:	m_begin((T*)&m_data[0]),
+		: m_begin((T*)&m_data[0]),
 		m_end(m_begin),
 		m_capacityEnd(m_begin + TCapacity),
 		m_allocator(allocator)
@@ -27,7 +27,7 @@ struct fixed_vector_storage
 #endif
 	{
 		/**/
-	}	
+	}
 	explicit fixed_vector_storage(e_noinitialize)
 	{
 	}
@@ -39,6 +39,7 @@ struct fixed_vector_storage
 		{
 			RDE_ASSERT(!"fixed_vector cannot grow");
 			// @TODO: do something more spectacular here... do NOT throw exception, tho :)
+			// ...like fireworks, perhaps? ~SK()
 		}
 		T* newBegin = static_cast<T*>(m_allocator.allocate(newCapacity * sizeof(T)));
 		const base_vector::size_type newSize = oldSize < newCapacity ? oldSize : newCapacity;
@@ -102,8 +103,8 @@ struct fixed_vector_storage
 #endif
 	}
 
-	typedef typename aligned_as<T>::res	etype_t;	
-	
+	typedef typename aligned_as<T>::res	etype_t;
+
 	T*						m_begin;
 	T*						m_end;
 	// Not T[], because we need uninitialized memory.
@@ -117,40 +118,45 @@ struct fixed_vector_storage
 
 //=============================================================================
 template<typename T, int TCapacity, bool TGrowOnOverflow,
-	class TAllocator = rde::allocator>
-class fixed_vector : public vector<T, TAllocator, 
-	fixed_vector_storage<T, TAllocator, TCapacity, TGrowOnOverflow> >
+	class TAllocator = rde::allocator
+>
+class fixed_vector: public vector<T, TAllocator,
+	fixed_vector_storage<T, TAllocator, TCapacity, TGrowOnOverflow>
+>
 {
-	typedef vector<T, TAllocator, 
-		fixed_vector_storage<T, TAllocator, TCapacity, TGrowOnOverflow> > base_vector;
-    typedef TAllocator allocator_type;
-    typedef typename base_vector::size_type size_type;
-    typedef T value_type;
+	typedef vector<T, TAllocator,
+		fixed_vector_storage<
+		T, TAllocator, TCapacity, TGrowOnOverflow
+		>
+	>                                       base_vector;
+	typedef TAllocator                      allocator_type;
+	typedef typename base_vector::size_type size_type;
+	typedef T                               value_type;
 public:
 	explicit fixed_vector(const allocator_type& allocator = allocator_type())
-	:	base_vector(allocator)
+		: base_vector(allocator)
 	{
 		/**/
 	}
 	explicit fixed_vector(size_type initialSize, const allocator_type& allocator = allocator_type())
-	:	base_vector(initialSize, allocator)
+		: base_vector(initialSize, allocator)
 	{
 		/**/
 	}
 	fixed_vector(const T* first, const T* last, const allocator_type& allocator = allocator_type())
-	:	base_vector(first, last, allocator)
+		: base_vector(first, last, allocator)
 	{
 		/**/
 	}
 	// @note: allocator is not copied from rhs.
 	// @note: will not perform default constructor for newly created objects.
 	fixed_vector(const fixed_vector& rhs, const allocator_type& allocator = allocator_type())
-	:	base_vector(rhs, allocator)
+		: base_vector(rhs, allocator)
 	{
 		/**/
 	}
 	explicit fixed_vector(e_noinitialize n)
-	:	base_vector(n)
+		: base_vector(n)
 	{
 		/**/
 	}
@@ -159,7 +165,7 @@ public:
 	{
 		if (&rhs != this)
 		{
-            base_vector::copy(rhs);
+			base_vector::copy(rhs);
 		}
 		return *this;
 	}
@@ -167,6 +173,7 @@ public:
 
 #pragma warning(pop)
 
-} // rde
+} // namespace rde
 
+//-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_FIXED_VECTOR_H

--- a/functional.h
+++ b/functional.h
@@ -33,7 +33,7 @@ struct equal_to
 	}
 };
 
-}
+} // namespace rde
 
 //-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_FUNCTIONAL_H

--- a/hash_map.h
+++ b/hash_map.h
@@ -11,567 +11,572 @@
 
 namespace rde
 {
-
 // Load factor is 7/8th.
-template<typename TKey, typename TValue, 
-    class THashFunc = rde::hash<TKey>,
-    class TKeyEqualFunc = rde::equal_to<TKey>,
-    class TAllocator = rde::allocator>
+template<typename TKey, typename TValue,
+	class THashFunc = rde::hash<TKey>,
+	class TKeyEqualFunc = rde::equal_to<TKey>,
+	class TAllocator = rde::allocator
+>
 class hash_map
 {
-    public:
-        typedef rde::pair<TKey, TValue>         value_type;
+public:
+	typedef rde::pair<TKey, TValue>         value_type;
 
-    //private:
-        struct node
-        {
-            static const hash_value_t kUnusedHash       = 0xFFFFFFFF;
-            static const hash_value_t kDeletedHash      = 0xFFFFFFFE;
+//private:
+	struct node
+	{
+		static const hash_value_t kUnusedHash       = 0xFFFFFFFF;
+		static const hash_value_t kDeletedHash      = 0xFFFFFFFE;
 
-            node(): hash(kUnusedHash) {}
+		node(): hash(kUnusedHash) {}
 
-            RDE_FORCEINLINE bool is_unused() const		{ return hash == kUnusedHash; }
-            RDE_FORCEINLINE bool is_deleted() const     { return hash == kDeletedHash; }
-            RDE_FORCEINLINE bool is_occupied() const	{ return hash < kDeletedHash; }
+		RDE_FORCEINLINE bool is_unused() const		{ return hash == kUnusedHash; }
+		RDE_FORCEINLINE bool is_deleted() const     { return hash == kDeletedHash; }
+		RDE_FORCEINLINE bool is_occupied() const	{ return hash < kDeletedHash; }
 
-            hash_value_t    hash;
-            value_type      data;
-        };
-        template<typename TNodePtr, typename TPtr, typename TRef>
-        class node_iterator
-        {
-            friend class hash_map;
-        public:
-            typedef forward_iterator_tag    iterator_category;
+		hash_value_t    hash;
+		value_type      data;
+	};
 
-            explicit node_iterator(TNodePtr node, const hash_map* map)
-            :	m_node(node),
-                m_map(map)
-            {/**/}
+	template<typename TNodePtr, typename TPtr, typename TRef>
+	class node_iterator
+	{
+		friend class hash_map;
+	public:
+		typedef forward_iterator_tag    iterator_category;
 
-            // const/non-const iterator copy cto
-            template<typename UNodePtr, typename UPtr, typename URef>
-            node_iterator(const node_iterator<UNodePtr, UPtr, URef>& rhs)
-            :	m_node(rhs.node()), 
-                m_map(rhs.get_map())
-            {/**/}
-                TRef operator*() const
-                {
-                    RDE_ASSERT(m_node != 0);
-                    return m_node->data;
-                }
-                TPtr operator->() const
-                {
-                    return &m_node->data;
-                }
-                RDE_FORCEINLINE TNodePtr node() const
-                {
-                    return m_node;
-                }
+		explicit node_iterator(TNodePtr node, const hash_map* map)
+			: m_node(node),
+			m_map(map)
+		{
+			/**/
+		}
 
-                node_iterator& operator++()
-                {
-                    RDE_ASSERT(m_node != 0);
-                    ++m_node;
-                    move_to_next_occupied_node();
-                    return *this;
-                }
-                node_iterator operator++(int)
-                {
-                    node_iterator copy(*this);
-                    ++(*this);
-                    return copy;
-                }
+		// const/non-const iterator copy ctor
+		template<typename UNodePtr, typename UPtr, typename URef>
+		node_iterator(const node_iterator<UNodePtr, UPtr, URef>& rhs)
+			: m_node(rhs.node()),
+			m_map(rhs.get_map())
+		{
+			 /**/
+		}
+		TRef operator*() const
+		{
+			RDE_ASSERT(m_node != 0);
+			return m_node->data;
+		}
+		TPtr operator->() const
+		{
+			return &m_node->data;
+		}
+		RDE_FORCEINLINE TNodePtr node() const
+		{
+			return m_node;
+		}
 
-                RDE_FORCEINLINE bool operator==(const node_iterator& rhs) const
-                {
-                    return rhs.m_node == m_node;
-                }
-                bool operator!=(const node_iterator& rhs) const
-                {
-                    return !(rhs == *this);
-                }
+		node_iterator& operator++()
+		{
+			RDE_ASSERT(m_node != 0);
+			++m_node;
+			move_to_next_occupied_node();
+			return *this;
+		}
+		node_iterator operator++(int)
+		{
+			node_iterator copy(*this);
+			++(*this);
+			return copy;
+		}
 
-                const hash_map* get_map() const { return m_map; }	
-                private:
-                void move_to_next_occupied_node()
-                {
-                    // @todo: save nodeEnd in constructor?
-                    TNodePtr nodeEnd = m_map->m_nodes + m_map->bucket_count();
-                    for (/**/; m_node < nodeEnd; ++m_node)
-                    {
-                        if (m_node->is_occupied())
-                            break;
-                    }
-                }
-                TNodePtr		m_node;
-                const hash_map*	m_map;
-            };
+		RDE_FORCEINLINE bool operator==(const node_iterator& rhs) const
+		{
+			return rhs.m_node == m_node;
+		}
+		bool operator!=(const node_iterator& rhs) const
+		{
+			return !(rhs == *this);
+		}
 
-    public:
-        typedef TKey																key_type;
-        typedef TValue																mapped_type;
-        typedef TAllocator															allocator_type;
-        typedef node_iterator<node*, value_type*, value_type&>						iterator;
-        typedef node_iterator<const node*, const value_type*, const value_type&>	const_iterator;
-        typedef int																	size_type;
-        static const size_type														kNodeSize = sizeof(node);
-        static const size_type														kInitialCapacity = 64;
+		const hash_map* get_map() const { return m_map; }
+	private:
+		void move_to_next_occupied_node()
+		{
+			// @todo: save nodeEnd in constructor?
+			TNodePtr nodeEnd = m_map->m_nodes + m_map->bucket_count();
+			for (/**/; m_node < nodeEnd; ++m_node)
+			{
+				if (m_node->is_occupied())
+					break;
+			}
+		}
+		TNodePtr		m_node;
+		const hash_map*	m_map;
+	};
 
-        hash_map()
-            :	m_nodes(&ms_emptyNode),
-            m_size(0),
-            m_capacity(0),
-            m_capacityMask(0),
-            m_numUsed(0)
-    {
-        RDE_ASSERT((kInitialCapacity & (kInitialCapacity - 1)) == 0);	// Must be power-of-two
-    }
-        explicit hash_map(const allocator_type& allocator)
-            :	m_nodes(&ms_emptyNode),
-            m_size(0),
-            m_capacity(0),
-            m_capacityMask(0),
-            m_numUsed(0),
-            m_allocator(allocator)
-    {
-        /**/
-    }
-        explicit hash_map(size_type initial_bucket_count,
-                const allocator_type& allocator = allocator_type())
-            :	m_nodes(&ms_emptyNode),
-            m_size(0),
-            m_capacity(0),
-            m_capacityMask(0),
-            m_numUsed(0),
-            m_allocator(allocator)
-    {
-        reserve(initial_bucket_count);
-    }
-        hash_map(size_type initial_bucket_count,
-                const THashFunc& hashFunc, 
-                const allocator_type& allocator = allocator_type())
-            :	m_nodes(&ms_emptyNode),
-            m_size(0),
-            m_capacity(0),
-            m_capacityMask(0),
-            m_numUsed(0),
-            m_hashFunc(hashFunc),
-            m_allocator(allocator)
-    {
-        reserve(initial_bucket_count);
-    }
-    hash_map(const hash_map& rhs, const allocator_type& allocator = allocator_type())
-        :	m_nodes(&ms_emptyNode),
-            m_size(0),
-            m_capacity(0),
-            m_capacityMask(0),
-            m_numUsed(0),
-            m_allocator(allocator)
-    {
-        *this = rhs;
-    }
-        explicit hash_map(e_noinitialize)
-        {
-            /**/
-        }
-        ~hash_map()
-        {
-            delete_nodes();
-        }
+public:
+	typedef TKey																key_type;
+	typedef TValue																mapped_type;
+	typedef TAllocator															allocator_type;
+	typedef node_iterator<node*, value_type*, value_type&>						iterator;
+	typedef node_iterator<const node*, const value_type*, const value_type&>	const_iterator;
+	typedef int																	size_type;
+	static const size_type														kNodeSize = sizeof(node);
+	static const size_type														kInitialCapacity = 64;
 
-        iterator begin()
-        {
-            iterator it(m_nodes, this);
-            it.move_to_next_occupied_node();
-            return it;
-        }
-        const_iterator begin() const
-        {
-            const_iterator it(m_nodes, this);
-            it.move_to_next_occupied_node();
-            return it;
-        }
-        iterator end()              { return iterator(m_nodes + m_capacity, this); }
-        const_iterator end() const	{ return const_iterator(m_nodes + m_capacity, this); }
+	hash_map()
+		: m_nodes(&ms_emptyNode),
+		m_size(0),
+		m_capacity(0),
+		m_capacityMask(0),
+		m_numUsed(0)
+	{
+		RDE_ASSERT((kInitialCapacity & (kInitialCapacity - 1)) == 0);	// Must be power-of-two
+	}
+	explicit hash_map(const allocator_type& allocator)
+		: m_nodes(&ms_emptyNode),
+		m_size(0),
+		m_capacity(0),
+		m_capacityMask(0),
+		m_numUsed(0),
+		m_allocator(allocator)
+	{
+		/**/
+	}
+	explicit hash_map(size_type initial_bucket_count,
+			const allocator_type& allocator = allocator_type())
+		: m_nodes(&ms_emptyNode),
+		m_size(0),
+		m_capacity(0),
+		m_capacityMask(0),
+		m_numUsed(0),
+		m_allocator(allocator)
+	{
+		reserve(initial_bucket_count);
+	}
+	hash_map(size_type initial_bucket_count,
+			const THashFunc& hashFunc,
+			const allocator_type& allocator = allocator_type())
+		: m_nodes(&ms_emptyNode),
+		m_size(0),
+		m_capacity(0),
+		m_capacityMask(0),
+		m_numUsed(0),
+		m_hashFunc(hashFunc),
+		m_allocator(allocator)
+	{
+		reserve(initial_bucket_count);
+	}
+	hash_map(const hash_map& rhs, const allocator_type& allocator = allocator_type())
+		: m_nodes(&ms_emptyNode),
+		m_size(0),
+		m_capacity(0),
+		m_capacityMask(0),
+		m_numUsed(0),
+		m_allocator(allocator)
+	{
+		*this = rhs;
+	}
+	explicit hash_map(e_noinitialize)
+	{
+		/**/
+	}
+	~hash_map()
+	{
+		delete_nodes();
+	}
 
-        // @note:	Added for compatiblity sake.
-        //			Personally, I consider it "risky". Use find/insert for more
-        //			explicit operations.
-        mapped_type& operator[](const key_type& key)
-        {
-            hash_value_t hash;
-            node* n = find_for_insert(key, &hash);
-            if (n == 0 || !n->is_occupied())
-            {
-                return insert_at(value_type(key, TValue()), n, hash).first->second;
-            }
-            return n->data.second;
-        }
-        // @note:	Doesn't copy allocator.
-        hash_map& operator=(const hash_map& rhs)
-        {
-            RDE_ASSERT(invariant());
-            if (&rhs != this)
-            {
-                clear();
-                if (m_capacity < rhs.bucket_count())
-                {
-                    delete_nodes();
-                    m_nodes = allocate_nodes(rhs.bucket_count());
-                    m_capacity = rhs.bucket_count();
-                    m_capacityMask = m_capacity - 1;
-                }
-                rehash(m_capacity, m_nodes, rhs.m_capacity, rhs.m_nodes, false);
-                m_size = rhs.size();
-                m_numUsed = rhs.m_numUsed;
-            }
-            RDE_ASSERT(invariant());
-            return *this;
-        }
-        void swap(hash_map& rhs)
-        {
-            if (&rhs != this)
-            {
-                RDE_ASSERT(invariant());
-                RDE_ASSERT(m_allocator == rhs.m_allocator);
-                rde::swap(m_nodes, rhs.m_nodes);
-                rde::swap(m_size, rhs.m_size);
-                rde::swap(m_capacity, rhs.m_capacity);
-                rde::swap(m_capacityMask, rhs.m_capacityMask);
-                rde::swap(m_numUsed, rhs.m_numUsed);
-                rde::swap(m_hashFunc, rhs.m_hashFunc);
-                rde::swap(m_keyEqualFunc, rhs.m_keyEqualFunc);
-                RDE_ASSERT(invariant());
-            }
-        }
+	iterator begin()
+	{
+		iterator it(m_nodes, this);
+		it.move_to_next_occupied_node();
+		return it;
+	}
+	const_iterator begin() const
+	{
+		const_iterator it(m_nodes, this);
+		it.move_to_next_occupied_node();
+		return it;
+	}
+	iterator end()              { return iterator(m_nodes + m_capacity, this); }
+	const_iterator end() const	{ return const_iterator(m_nodes + m_capacity, this); }
 
-        rde::pair<iterator, bool> insert(const value_type& v)
-        {
-            return emplace(v.first, v.second);
-        }
-        template<class K = key_type, class... Args>
-        rde::pair<iterator, bool> emplace(K&& key, Args&&... args)
-        {
-            RDE_ASSERT(invariant());
-            if (m_numUsed * 8 >= m_capacity * 7)
-                grow();
+	// @note:	Added for compatiblity sake.
+	//			Personally, I consider it "risky". Use find/insert for more
+	//			explicit operations.
+	mapped_type& operator[](const key_type& key)
+	{
+		hash_value_t hash;
+		node* n = find_for_insert(key, &hash);
+		if (n == 0 || !n->is_occupied())
+		{
+			return insert_at(value_type(key, TValue()), n, hash).first->second;
+		}
+		return n->data.second;
+	}
+	// @note:	Doesn't copy allocator.
+	hash_map& operator=(const hash_map& rhs)
+	{
+		RDE_ASSERT(invariant());
+		if (&rhs != this)
+		{
+			clear();
+			if (m_capacity < rhs.bucket_count())
+			{
+				delete_nodes();
+				m_nodes = allocate_nodes(rhs.bucket_count());
+				m_capacity = rhs.bucket_count();
+				m_capacityMask = m_capacity - 1;
+			}
+			rehash(m_capacity, m_nodes, rhs.m_capacity, rhs.m_nodes, false);
+			m_size = rhs.size();
+			m_numUsed = rhs.m_numUsed;
+		}
+		RDE_ASSERT(invariant());
+		return *this;
+	}
+	void swap(hash_map& rhs)
+	{
+		if (&rhs != this)
+		{
+			RDE_ASSERT(invariant());
+			RDE_ASSERT(m_allocator == rhs.m_allocator);
+			rde::swap(m_nodes, rhs.m_nodes);
+			rde::swap(m_size, rhs.m_size);
+			rde::swap(m_capacity, rhs.m_capacity);
+			rde::swap(m_capacityMask, rhs.m_capacityMask);
+			rde::swap(m_numUsed, rhs.m_numUsed);
+			rde::swap(m_hashFunc, rhs.m_hashFunc);
+			rde::swap(m_keyEqualFunc, rhs.m_keyEqualFunc);
+			RDE_ASSERT(invariant());
+		}
+	}
 
-            hash_value_t hash;
-            node* n = find_for_insert(key, &hash);
- 
-            return emplace_at(n, hash, std::forward<K>(key), std::forward<Args>(args)...);
-        }
+	rde::pair<iterator, bool> insert(const value_type& v)
+	{
+		return emplace(v.first, v.second);
+	}
+	template<class K = key_type, class... Args>
+	rde::pair<iterator, bool> emplace(K&& key, Args&&... args)
+	{
+		RDE_ASSERT(invariant());
+		if (m_numUsed * 8 >= m_capacity * 7)
+			grow();
 
-        size_type erase(const key_type& key)
-        {
-            node* n = lookup(key);
-            if (n != (m_nodes + m_capacity) && n->is_occupied())
-            {
-                erase_node(n);
-                return 1;
-            }
-            return 0;
-        }
-        void erase(iterator it)
-        {
-            RDE_ASSERT(it.get_map() == this);
-            if (it != end())
-            {
-                RDE_ASSERT(!empty());
-                erase_node(it.node());
-            }
-        }
-        void erase(iterator from, iterator to)
-        {
-            for (/**/; from != to; ++from)
-            {
-                node* n = from.node();
-                if (n->is_occupied())
-                    erase_node(n);
-            }
-        }
+		hash_value_t hash;
+		node* n = find_for_insert(key, &hash);
 
-        iterator find(const key_type& key)
-        {
-            node* n = lookup(key);
-            return iterator(n, this);
-        }
-        const_iterator find(const key_type& key) const
-        {
-            const node* n = lookup(key);
-            return const_iterator(n, this);
-        }
+		return emplace_at(n, hash, std::forward<K>(key), std::forward<Args>(args)...);
+	}
 
-        void clear()
-        {
-            node* endNode = m_nodes + m_capacity;
-            for (node* iter = m_nodes; iter != endNode; ++iter)
-            {
-                if( iter )
-                {
-                    if (iter->is_occupied())
-                    {
-                        rde::destruct(&iter->data);
-                    }
-                    // We can make them unused, because we clear whole hash_map,
-                    // so we can guarantee there'll be no holes.
-                    iter->hash = node::kUnusedHash;
-                }
-            }
-            m_size = 0;
-            m_numUsed = 0;
-        }
+	size_type erase(const key_type& key)
+	{
+		node* n = lookup(key);
+		if (n != (m_nodes + m_capacity) && n->is_occupied())
+		{
+			erase_node(n);
+			return 1;
+		}
+		return 0;
+	}
+	void erase(iterator it)
+	{
+		RDE_ASSERT(it.get_map() == this);
+		if (it != end())
+		{
+			RDE_ASSERT(!empty());
+			erase_node(it.node());
+		}
+	}
+	void erase(iterator from, iterator to)
+	{
+		for (/**/; from != to; ++from)
+		{
+			node* n = from.node();
+			if (n->is_occupied())
+				erase_node(n);
+		}
+	}
 
-        void reserve(size_type min_size)
-        {
-            size_type newCapacity = (m_capacity == 0 ? kInitialCapacity : m_capacity);
-            while (newCapacity < min_size)
-                newCapacity *= 2;
-            if (newCapacity > m_capacity)
-                grow(newCapacity);
-        }
+	iterator find(const key_type& key)
+	{
+		node* n = lookup(key);
+		return iterator(n, this);
+	}
+	const_iterator find(const key_type& key) const
+	{
+		const node* n = lookup(key);
+		return const_iterator(n, this);
+	}
 
-        size_type bucket_count() const			{ return m_capacity; }
-        size_type size() const					{ return m_size; }
-        size_type empty() const					{ return size() == 0; }
-        size_type nonempty_bucket_count() const	{ return m_numUsed; }
-        size_type used_memory() const				
-        {
-            return bucket_count() * kNodeSize;
-        }
+	void clear()
+	{
+		node* endNode = m_nodes + m_capacity;
+		for (node* iter = m_nodes; iter != endNode; ++iter)
+		{
+			if (iter)
+			{
+				if (iter->is_occupied())
+				{
+					rde::destruct(&iter->data);
+				}
+				// We can make them unused, because we clear whole hash_map,
+				// so we can guarantee there'll be no holes.
+				iter->hash = node::kUnusedHash;
+			}
+		}
+		m_size = 0;
+		m_numUsed = 0;
+	}
 
-        const allocator_type& get_allocator() const	{ return m_allocator; }
-        void set_allocator(const allocator_type& allocator)
-        {
-            m_allocator = allocator;
-        }
+	void reserve(size_type min_size)
+	{
+		size_type newCapacity = (m_capacity == 0 ? kInitialCapacity : m_capacity);
+		while (newCapacity < min_size)
+			newCapacity *= 2;
+		if (newCapacity > m_capacity)
+			grow(newCapacity);
+	}
 
-    private:
-        void grow()
-        {
-            const int newCapacity = (m_capacity == 0 ? kInitialCapacity : m_capacity * 2);
-            grow(newCapacity);
-        }
-        void grow(int new_capacity)
-        {
-            RDE_ASSERT((new_capacity & (new_capacity - 1)) == 0);	// Must be power-of-two
-            node* newNodes = allocate_nodes(new_capacity);
-            rehash(new_capacity, newNodes, m_capacity, m_nodes, true);
-            if (m_nodes != &ms_emptyNode)
-                m_allocator.deallocate(m_nodes, sizeof(node) * m_capacity);
-            m_capacity = new_capacity;
-            m_capacityMask = new_capacity - 1;
-            m_nodes = newNodes;
-            m_numUsed = m_size;
-            RDE_ASSERT(m_numUsed < m_capacity);
-        }
-        template<class K = key_type, class... Args>
-        RDE_FORCEINLINE rde::pair<iterator, bool> emplace_at(node* n, hash_value_t hash, K&& key, Args&&... args)
-        {
-            typedef rde::pair<iterator, bool> ret_type_t;
-            if (n->is_occupied())
-            {
-                RDE_ASSERT(hash == n->hash && m_keyEqualFunc(key, n->data.first));
-                return ret_type_t(iterator(n, this), false);
-            }
-            if (n->is_unused())
-            {
-                ++m_numUsed;
-            }
-            rde::construct_args(&n->data,
-                std::forward<K>(key),
-                std::forward<Args>(args)...);
-            n->hash = hash;
-            ++m_size;
-            RDE_ASSERT(invariant());
-            return ret_type_t(iterator(n, this), true);
-        }
- 
-        rde::pair<iterator, bool> insert_at(const value_type& v, node* n, 
-                hash_value_t hash)
-        {
-            RDE_ASSERT(invariant());
-            if (n == 0 || m_numUsed * 8 >= m_capacity * 7)
-                return insert(v);
+	size_type bucket_count() const			{ return m_capacity; }
+	size_type size() const					{ return m_size; }
+	size_type empty() const					{ return size() == 0; }
+	size_type nonempty_bucket_count() const	{ return m_numUsed; }
+	size_type used_memory() const
+	{
+		return bucket_count() * kNodeSize;
+	}
 
-            RDE_ASSERT(!n->is_occupied());
-            return emplace_at(n, hash, v.first, v.second);
-        }
-        node* find_for_insert(const key_type& key, hash_value_t* out_hash)
-        {
-            if (m_capacity == 0)
-                return 0;
+	const allocator_type& get_allocator() const	{ return m_allocator; }
+	void set_allocator(const allocator_type& allocator)
+	{
+		m_allocator = allocator;
+	}
 
-            const hash_value_t hash = hash_func(key);
-            *out_hash = hash;
-            uint32 i = hash & m_capacityMask;
+private:
+	void grow()
+	{
+		const int newCapacity = (m_capacity == 0 ? kInitialCapacity : m_capacity * 2);
+		grow(newCapacity);
+	}
+	void grow(int new_capacity)
+	{
+		RDE_ASSERT((new_capacity & (new_capacity - 1)) == 0);	// Must be power-of-two
+		node* newNodes = allocate_nodes(new_capacity);
+		rehash(new_capacity, newNodes, m_capacity, m_nodes, true);
+		if (m_nodes != &ms_emptyNode)
+			m_allocator.deallocate(m_nodes, sizeof(node) * m_capacity);
+		m_capacity = new_capacity;
+		m_capacityMask = new_capacity - 1;
+		m_nodes = newNodes;
+		m_numUsed = m_size;
+		RDE_ASSERT(m_numUsed < m_capacity);
+	}
+	template<class K = key_type, class... Args>
+	RDE_FORCEINLINE rde::pair<iterator, bool> emplace_at(node* n, hash_value_t hash, K&& key, Args&&... args)
+	{
+		typedef rde::pair<iterator, bool> ret_type_t;
+		if (n->is_occupied())
+		{
+			RDE_ASSERT(hash == n->hash && m_keyEqualFunc(key, n->data.first));
+			return ret_type_t(iterator(n, this), false);
+		}
+		if (n->is_unused())
+		{
+			++m_numUsed;
+		}
+		rde::construct_args(&n->data,
+			std::forward<K>(key),
+			std::forward<Args>(args)...);
+		n->hash = hash;
+		++m_size;
+		RDE_ASSERT(invariant());
+		return ret_type_t(iterator(n, this), true);
+	}
 
-            node* n = m_nodes + i;
-            if (n->hash == hash && m_keyEqualFunc(key, n->data.first))
-                return n;
+	rde::pair<iterator, bool> insert_at(const value_type& v, node* n,
+			hash_value_t hash)
+	{
+		RDE_ASSERT(invariant());
+		if (n == 0 || m_numUsed * 8 >= m_capacity * 7)
+			return insert(v);
 
-            node* freeNode(0);
-            if (n->is_deleted())
-                freeNode = n;
-            uint32 numProbes(1);
-            // Guarantees loop termination.
-            RDE_ASSERT(m_numUsed < m_capacity);
-            while (!n->is_unused())
-            {
-                i = (i + numProbes) & m_capacityMask;
-                n = m_nodes + i;
-                if (compare_key(n, key, hash))
-                    return n;
-                if (n->is_deleted() && freeNode == 0)
-                    freeNode = n;
-                ++numProbes;
-            }
-            return freeNode ? freeNode : n;
-        }
-        node* lookup(const key_type& key) const
-        {
-            const hash_value_t hash = hash_func(key);
-            uint32 i = hash & m_capacityMask;
-            node* n = m_nodes + i;
-            if (n->hash == hash && m_keyEqualFunc(key, n->data.first))
-                return n;
+		RDE_ASSERT(!n->is_occupied());
+		return emplace_at(n, hash, v.first, v.second);
+	}
+	node* find_for_insert(const key_type& key, hash_value_t* out_hash)
+	{
+		if (m_capacity == 0)
+			return 0;
 
-            uint32 numProbes(1);
-            // Guarantees loop termination.
-            RDE_ASSERT(m_capacity == 0 || m_numUsed < m_capacity);
-            while (!n->is_unused())
-            {
-                i = (i + numProbes) & m_capacityMask;
-                n = m_nodes + i;
+		const hash_value_t hash = hash_func(key);
+		*out_hash = hash;
+		uint32 i = hash & m_capacityMask;
 
-                if (compare_key(n, key, hash))
-                    return n;
+		node* n = m_nodes + i;
+		if (n->hash == hash && m_keyEqualFunc(key, n->data.first))
+			return n;
 
-                ++numProbes;
-            }
-            return m_nodes + m_capacity;
-        }
+		node* freeNode(0);
+		if (n->is_deleted())
+			freeNode = n;
+		uint32 numProbes(1);
+		// Guarantees loop termination.
+		RDE_ASSERT(m_numUsed < m_capacity);
+		while (!n->is_unused())
+		{
+			i = (i + numProbes) & m_capacityMask;
+			n = m_nodes + i;
+			if (compare_key(n, key, hash))
+				return n;
+			if (n->is_deleted() && freeNode == 0)
+				freeNode = n;
+			++numProbes;
+		}
+		return freeNode ? freeNode : n;
+	}
+	node* lookup(const key_type& key) const
+	{
+		const hash_value_t hash = hash_func(key);
+		uint32 i = hash & m_capacityMask;
+		node* n = m_nodes + i;
+		if (n->hash == hash && m_keyEqualFunc(key, n->data.first))
+			return n;
 
-        static void rehash(int new_capacity, node* new_nodes,
-                int capacity, const node* nodes, bool destruct_original)
-        {
-            //if (nodes == &ms_emptyNode || new_nodes == &ms_emptyNode)
-            //  return;
+		uint32 numProbes(1);
+		// Guarantees loop termination.
+		RDE_ASSERT(m_capacity == 0 || m_numUsed < m_capacity);
+		while (!n->is_unused())
+		{
+			i = (i + numProbes) & m_capacityMask;
+			n = m_nodes + i;
 
-            node* it = const_cast<node*>(nodes);
-            const node* itEnd = nodes + capacity;
-            const uint32 mask = new_capacity - 1;
-            while (it != itEnd)
-            {
-                if (it->is_occupied())
-                {
-                    const hash_value_t hash = it->hash;
-                    uint32 i = hash & mask;
+			if (compare_key(n, key, hash))
+				return n;
 
-                    node* n = new_nodes + i;
-                    uint32 numProbes(0);
-                    while (!n->is_unused())
-                    {
-                        ++numProbes;
-                        i = (i + numProbes) & mask;
-                        n = new_nodes + i;
-                    }
-                    // rehash is not inlined, so branch will not be eliminated, even though
-                    // it's known at compile-time. It should be easily predictable though
-                    // as it's always true/false for each iteration.
-                    // an alternative would be to either inline it or make a template argument.
-                    // Both would bloat the code a bit.
-                    if (destruct_original)
-                    {
-                        rde::construct_args(&n->data, std::move(it->data));
-                        rde::destruct(&it->data);
-                    }
-                    else
-                    {
-                        rde::copy_construct(&n->data, it->data);
-                    }
-                    n->hash = hash;
-                }
-                ++it;
-            }
-        }
+			++numProbes;
+		}
+		return m_nodes + m_capacity;
+	}
 
-        node* allocate_nodes(int n)
-        {
-            node* buckets = static_cast<node*>(m_allocator.allocate(n * sizeof(node)));
-            node* iterBuckets(buckets);
-            node* end = iterBuckets + n;
-            for (/**/; iterBuckets != end; ++iterBuckets)
-                iterBuckets->hash = node::kUnusedHash;
+	static void rehash(int new_capacity, node* new_nodes,
+			int capacity, const node* nodes, bool destruct_original)
+	{
+		//if (nodes == &ms_emptyNode || new_nodes == &ms_emptyNode)
+		//  return;
 
-            return buckets;
-        }
-        void delete_nodes()
-        {
-            node* it = m_nodes;
-            node* itEnd = it + m_capacity;
-            while (it != itEnd)
-            {
-                if (it && it->is_occupied())
-                    rde::destruct(&it->data);
-                ++it;
-            }
-            if (m_nodes != &ms_emptyNode)
-                m_allocator.deallocate(m_nodes, sizeof(node) * m_capacity);
+		node* it = const_cast<node*>(nodes);
+		const node* itEnd = nodes + capacity;
+		const uint32 mask = new_capacity - 1;
+		while (it != itEnd)
+		{
+			if (it->is_occupied())
+			{
+				const hash_value_t hash = it->hash;
+				uint32 i = hash & mask;
 
-            m_capacity = 0;
-            m_capacityMask = 0;
-            m_size = 0;
-        }
-        void erase_node(node* n)
-        {
-            RDE_ASSERT(!empty());
-            RDE_ASSERT(n->is_occupied());
-            rde::destruct(&n->data);
-            n->hash = node::kDeletedHash;
-            --m_size;
-        }
+				node* n = new_nodes + i;
+				uint32 numProbes(0);
+				while (!n->is_unused())
+				{
+					++numProbes;
+					i = (i + numProbes) & mask;
+					n = new_nodes + i;
+				}
+				// rehash is not inlined, so branch will not be eliminated, even though
+				// it's known at compile-time. It should be easily predictable though
+				// as it's always true/false for each iteration.
+				// an alternative would be to either inline it or make a template argument.
+				// Both would bloat the code a bit.
+				if (destruct_original)
+				{
+					rde::construct_args(&n->data, std::move(it->data));
+					rde::destruct(&it->data);
+				}
+				else
+				{
+					rde::copy_construct(&n->data, it->data);
+				}
+				n->hash = hash;
+			}
+			++it;
+		}
+	}
 
-        RDE_FORCEINLINE hash_value_t hash_func(const key_type& key) const
-        {
-            const hash_value_t h = m_hashFunc(key) & 0xFFFFFFFD;
-            //RDE_ASSERT(h < node::kDeletedHash);
-            return h;
-        }
-        bool invariant() const
-        {
-            RDE_ASSERT((m_capacity & (m_capacity - 1)) == 0);
-            RDE_ASSERT(m_numUsed >= m_size);
-            return true;
-        }
+	node* allocate_nodes(int n)
+	{
+		node* buckets = static_cast<node*>(m_allocator.allocate(n * sizeof(node)));
+		node* iterBuckets(buckets);
+		node* end = iterBuckets + n;
+		for (/**/; iterBuckets != end; ++iterBuckets)
+			iterBuckets->hash = node::kUnusedHash;
 
-        RDE_FORCEINLINE bool compare_key(const node* n, const key_type& key, hash_value_t hash) const
-        {
-            return (n->hash == hash && m_keyEqualFunc(key, n->data.first));
-        }
+		return buckets;
+	}
+	void delete_nodes()
+	{
+		node* it = m_nodes;
+		node* itEnd = it + m_capacity;
+		while (it != itEnd)
+		{
+			if (it && it->is_occupied())
+				rde::destruct(&it->data);
+			++it;
+		}
+		if (m_nodes != &ms_emptyNode)
+			m_allocator.deallocate(m_nodes, sizeof(node) * m_capacity);
 
-        node*			m_nodes;
-        int				m_size;
-        int				m_capacity;
-        uint32			m_capacityMask;
-        int				m_numUsed;
-        THashFunc       m_hashFunc;
-        TKeyEqualFunc	m_keyEqualFunc;
-        TAllocator      m_allocator;
+		m_capacity = 0;
+		m_capacityMask = 0;
+		m_size = 0;
+	}
+	void erase_node(node* n)
+	{
+		RDE_ASSERT(!empty());
+		RDE_ASSERT(n->is_occupied());
+		rde::destruct(&n->data);
+		n->hash = node::kDeletedHash;
+		--m_size;
+	}
 
-        static node		ms_emptyNode;
+	RDE_FORCEINLINE hash_value_t hash_func(const key_type& key) const
+	{
+		const hash_value_t h = m_hashFunc(key) & 0xFFFFFFFD;
+		//RDE_ASSERT(h < node::kDeletedHash);
+		return h;
+	}
+	bool invariant() const
+	{
+		RDE_ASSERT((m_capacity & (m_capacity - 1)) == 0);
+		RDE_ASSERT(m_numUsed >= m_size);
+		return true;
+	}
+
+	RDE_FORCEINLINE bool compare_key(const node* n, const key_type& key, hash_value_t hash) const
+	{
+		return (n->hash == hash && m_keyEqualFunc(key, n->data.first));
+	}
+
+	node*			m_nodes;
+	int				m_size;
+	int				m_capacity;
+	uint32			m_capacityMask;
+	int				m_numUsed;
+	THashFunc       m_hashFunc;
+	TKeyEqualFunc	m_keyEqualFunc;
+	TAllocator      m_allocator;
+
+	static node		ms_emptyNode;
 };
 
-
 // Holy ...
-template<typename TKey, typename TValue, 
-    class THashFunc,
-    class TKeyEqualFunc,
-    class TAllocator>
-        typename hash_map<TKey, TValue, THashFunc, TKeyEqualFunc, TAllocator>::node hash_map<TKey, TValue, THashFunc, TKeyEqualFunc, TAllocator>::ms_emptyNode;
+template<typename TKey, typename TValue,
+	class THashFunc,
+	class TKeyEqualFunc,
+	class TAllocator
+>
+typename hash_map<TKey, TValue, THashFunc, TKeyEqualFunc, TAllocator>::node hash_map<TKey, TValue, THashFunc, TKeyEqualFunc, TAllocator>::ms_emptyNode;
 
-} // rde
+} // namespace rde
 
-#endif
-
+//-----------------------------------------------------------------------------
+#endif // #ifndef RDESTL_HASH_MAP_H

--- a/int_to_type.h
+++ b/int_to_type.h
@@ -3,25 +3,25 @@
 
 namespace rde
 {
-
 /**
  * Sample usage:
  *	void fun(int_to_type<true>)  { ... }
  *  void fun(int_to_type<false>) { ... }
- *  template<typename T> void bar() 
- *  { 
+ *  template<typename T> void bar()
+ *  {
  *		fun(int_to_type<std::numeric_limits<T>::is_exact>())
  *  }
  */
 template<int TVal>
 struct int_to_type
 {
-    enum 
-    {
-        value = TVal
-    };
+	enum
+	{
+		value = TVal
+	};
 };
 
 } // namespaces
 
+//-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_INT_TO_TYPE_H

--- a/intrusive_list.cpp
+++ b/intrusive_list.cpp
@@ -3,7 +3,7 @@
 namespace rde
 {
 	intrusive_list_base::intrusive_list_base()
-	:	m_root()
+		: m_root()
 	{
 		/**/
 	}
@@ -16,7 +16,8 @@ namespace rde
 		{
 			iter = iter->next;
 			++numNodes;
-		} while (iter != &m_root);
+		}
+		while (iter != &m_root);
 		return numNodes - 1;
 	}
 
@@ -35,4 +36,5 @@ namespace rde
 		node->next->prev = node->prev;
 		node->next = node->prev = node;
 	}
-}
+
+} // namespace rde

--- a/intrusive_list.h
+++ b/intrusive_list.h
@@ -6,7 +6,6 @@
 
 namespace rde
 {
-
 //=============================================================================
 struct intrusive_list_node
 {
@@ -29,9 +28,9 @@ public:
 	typedef Reference					reference;
 	typedef bidirectional_iterator_tag	iterator_category;
 
-	intrusive_list_iterator():	m_node(0) {/**/}
+	intrusive_list_iterator(): m_node(0) { /**/ }
 	explicit intrusive_list_iterator(Pointer iterNode)
-	:	m_node(iterNode)
+		: m_node(iterNode)
 	{
 		/**/
 	}
@@ -125,7 +124,7 @@ private:
 // Can store pointers only.
 // Type should be derived from intrusive_list_node.
 template<class T>
-class intrusive_list : public intrusive_list_base
+class intrusive_list: public intrusive_list_base
 {
 public:
 	typedef T											node_type;
@@ -133,7 +132,7 @@ public:
 	typedef intrusive_list_iterator<T*, T&>				iterator;
 	typedef intrusive_list_iterator<const T*, const T&>	const_iterator;
 
-	intrusive_list() : intrusive_list_base()
+	intrusive_list(): intrusive_list_base()
 	{
 		// Compile error if T not derived from intrusive_list_node
 		intrusive_list_node* testNode((T*)0);
@@ -141,7 +140,7 @@ public:
 	}
 
 	void push_back(value_type* v)
-	{		
+	{
 		link(v, &m_root);
 	}
 	void push_front(value_type* v)

--- a/intrusive_slist.cpp
+++ b/intrusive_slist.cpp
@@ -15,7 +15,8 @@ namespace rde
 		{
 			iter = iter->next;
 			++numNodes;
-		} while (iter != &m_root);
+		}
+		while (iter != &m_root);
 		return numNodes - 1;
 	}
 
@@ -32,4 +33,5 @@ namespace rde
 		node->next = thisNode->next;
 		thisNode->next = thisNode;
 	}
-}
+
+} // namespace rde

--- a/intrusive_slist.h
+++ b/intrusive_slist.h
@@ -28,9 +28,9 @@ public:
 	typedef Reference				reference;
 	typedef forward_iterator_tag	iterator_category;
 
-	intrusive_slist_iterator():	m_node(0) {/**/}
+	intrusive_slist_iterator(): m_node(0) { /**/ }
 	explicit intrusive_slist_iterator(Pointer iterNode)
-	:	m_node(iterNode)
+		: m_node(iterNode)
 	{
 		/**/
 	}
@@ -108,7 +108,7 @@ private:
 //=============================================================================
 // Can store pointers only!
 template<class T>
-class intrusive_slist : public intrusive_slist_base
+class intrusive_slist: public intrusive_slist_base
 {
 public:
 	typedef T												node_type;
@@ -175,7 +175,7 @@ public:
 		return iterator(v);
 	}
 	// O(1)
-	static const_iterator get_iterator(const value_type* v) 
+	static const_iterator get_iterator(const value_type* v)
 	{
 		RDE_ASSERT(v->in_list());
 		return const_iterator(v);

--- a/iterator.h
+++ b/iterator.h
@@ -5,7 +5,6 @@
 
 namespace rde
 {
-
 //-----------------------------------------------------------------------------
 struct input_iterator_tag {};
 struct output_iterator_tag {};
@@ -14,63 +13,64 @@ struct bidirectional_iterator_tag: public forward_iterator_tag {};
 struct random_access_iterator_tag: public bidirectional_iterator_tag {};
 
 //-----------------------------------------------------------------------------
-template<typename IterT>
-struct iterator_traits 
+template<typename TIter>
+struct iterator_traits
 {
-   typedef typename IterT::iterator_category iterator_category;
+	typedef typename TIter::iterator_category iterator_category;
 };
 
-template<typename T>          
-struct iterator_traits<T*> 
+template<typename T>
+struct iterator_traits<T*>
 {
-   typedef random_access_iterator_tag iterator_category;
+	typedef random_access_iterator_tag iterator_category;
 };
 
 //-----------------------------------------------------------------------------
 namespace internal
 {
-	template<typename TIter, typename TDist> RDE_FORCEINLINE
-	void distance(TIter first, TIter last, TDist& dist, rde::random_access_iterator_tag)
+template<typename TIter, typename TDist> RDE_FORCEINLINE
+void distance(TIter first, TIter last, TDist& dist, rde::random_access_iterator_tag)
+{
+	dist = TDist(last - first);
+}
+template<typename TIter, typename TDist> RDE_FORCEINLINE
+void distance(TIter first, TIter last, TDist& dist, rde::input_iterator_tag)
+{
+	dist = 0;
+	while (first != last)
 	{
-		dist = TDist(last - first);
+		++dist;
+		++first;
 	}
-	template<typename TIter, typename TDist> RDE_FORCEINLINE
-	void distance(TIter first, TIter last, TDist& dist, rde::input_iterator_tag)
-	{
-		dist = 0;
-		while (first != last)
-		{
-			++dist;
-			++first;
-		}
-	}
+}
 
-	template<typename TIter, typename TDist> RDE_FORCEINLINE
-	void advance(TIter& iter, TDist d, rde::random_access_iterator_tag)
+template<typename TIter, typename TDist> RDE_FORCEINLINE
+void advance(TIter& iter, TDist d, rde::random_access_iterator_tag)
+{
+	iter += d;
+}
+template<typename TIter, typename TDist> RDE_FORCEINLINE
+void advance(TIter& iter, TDist d, rde::bidirectional_iterator_tag)
+{
+	if (d >= 0)
 	{
-		iter += d;
-	}
-	template<typename TIter, typename TDist> RDE_FORCEINLINE
-	void advance(TIter& iter, TDist d, rde::bidirectional_iterator_tag)
-	{
-		if (d >= 0)
-		{
-			while (d--)
-				++iter;
-		}
-		else
-		{
-			while (d++)
-				--iter;
-		}
-	}
-	template<typename TIter, typename TDist> RDE_FORCEINLINE
-	void advance(TIter& iter, TDist d, rde::input_iterator_tag)
-	{
-		RDE_ASSERT(d >= 0);
 		while (d--)
 			++iter;
 	}
+	else
+	{
+		while (d++)
+			--iter;
+	}
+}
+template<typename TIter, typename TDist> RDE_FORCEINLINE
+void advance(TIter& iter, TDist d, rde::input_iterator_tag)
+{
+	RDE_ASSERT(d >= 0);
+	while (d--)
+		++iter;
+}
+
 } // namespace internal
 } // namespace rde
 

--- a/list.cpp
+++ b/list.cpp
@@ -2,22 +2,23 @@
 
 namespace rde
 {
-	namespace internal
+namespace internal
+{
+	void list_base_node::link_before(list_base_node* nextNode)
 	{
-		void list_base_node::link_before(list_base_node* nextNode)
-		{
-			RDE_ASSERT(!in_list());
-			prev = nextNode->prev;
-			prev->next = this;
-			nextNode->prev = this;
-			next = nextNode;
-		}
-		void list_base_node::unlink()
-		{
-			RDE_ASSERT(in_list());
-			prev->next = next;
-			next->prev = prev;
-			next = prev = this;
-		}
-	} // internal
-}
+		RDE_ASSERT(!in_list());
+		prev = nextNode->prev;
+		prev->next = this;
+		nextNode->prev = this;
+		next = nextNode;
+	}
+	void list_base_node::unlink()
+	{
+		RDE_ASSERT(in_list());
+		prev->next = next;
+		next->prev = prev;
+		next = prev = this;
+	}
+
+} // namespace internal
+} // namespace rde

--- a/list.h
+++ b/list.h
@@ -8,36 +8,36 @@ namespace rde
 {
 namespace internal
 {
-	struct list_base_node
+struct list_base_node
+{
+	list_base_node()
 	{
-		list_base_node()
-		{
 #if RDE_DEBUG
-			reset();
+		reset();
 #endif
-		}
-		void reset()
-		{
-			next = prev = this;
-		}
-		bool in_list() const { return this != next; }
+	}
+	void reset()
+	{
+		next = prev = this;
+	}
+	bool in_list() const { return this != next; }
 
-		void link_before(list_base_node* nextNode);
-		void unlink();
+	void link_before(list_base_node* nextNode);
+	void unlink();
 
-		list_base_node* prev;
-		list_base_node*	next;
-	};
-}
+	list_base_node* prev;
+	list_base_node*	next;
+};
+} // namespace internal
 
 //=============================================================================
 template<typename T, class TAllocator = rde::allocator>
 class list
 {
 private:
-	struct node : public internal::list_base_node
+	struct node: public internal::list_base_node
 	{
-		node():	list_base_node() {}
+		node(): list_base_node() {}
 		explicit node(const T& v): list_base_node(), value(v) {}
 
 		T		value;
@@ -53,13 +53,13 @@ private:
 	public:
 		typedef bidirectional_iterator_tag	iterator_category;
 
-        explicit node_iterator(): m_node(NULL) {/**/}
-		
-        explicit node_iterator(TNodePtr node):	m_node(node) {/**/}
-        
+		explicit node_iterator(): m_node(NULL) { /**/ }
+
+		explicit node_iterator(TNodePtr node): m_node(node) { /**/ }
+
 		template<typename UNodePtr, typename UPtr, typename URef>
 		node_iterator(const node_iterator<UNodePtr, UPtr, URef>& rhs)
-		:	m_node(rhs.node())
+			: m_node(rhs.node())
 		{
 			/**/
 		}
@@ -115,28 +115,28 @@ private:
 	};
 
 public:
-	typedef T													value_type;
-	typedef TAllocator											allocator_type;
-	typedef int 												size_type;
-	typedef node_iterator<node*, T*, T&>						iterator;
+	typedef T												value_type;
+	typedef TAllocator										allocator_type;
+	typedef int 											size_type;
+	typedef node_iterator<node*, T*, T&>					iterator;
 	typedef node_iterator<const node*, const T*, const T&>	const_iterator;
-	static const std::size_t									kNodeSize = sizeof(node);
+	static const std::size_t								kNodeSize = sizeof(node);
 
 	explicit list(const allocator_type& allocator = allocator_type())
-	:	m_allocator(allocator)
+		: m_allocator(allocator)
 	{
 		m_root.reset();
 	}
 	template<class InputIterator>
-	list(InputIterator first, InputIterator last, 
+	list(InputIterator first, InputIterator last,
 		const allocator_type& allocator = allocator_type())
-	:	m_allocator(allocator)
+		: m_allocator(allocator)
 	{
 		m_root.reset();
 		assign(first, last);
 	}
 	list(const list& rhs, const allocator_type& allocator = allocator_type())
-	:	m_allocator(allocator)
+		: m_allocator(allocator)
 	{
 		m_root.reset();
 		assign(rhs.begin(), rhs.end());
@@ -160,10 +160,10 @@ public:
 	iterator end()					{ return iterator(&m_root); }
 	const_iterator end() const		{ return const_iterator(&m_root); }
 
-	const T& front() const	{ RDE_ASSERT(!empty()); return upcast(m_root.next)->value; }
-	T& front()				{ RDE_ASSERT(!empty()); return upcast(m_root.next)->value; }
-	const T& back() const	{ RDE_ASSERT(!empty()); return upcast(m_root.prev)->value; }
-	T& back()				{ RDE_ASSERT(!empty()); return upcast(m_root.prev)->value; }
+	T& front()						{ RDE_ASSERT(!empty()); return upcast(m_root.next)->value; }
+	const T& front() const			{ RDE_ASSERT(!empty()); return upcast(m_root.next)->value; }
+	T& back()						{ RDE_ASSERT(!empty()); return upcast(m_root.prev)->value; }
+	const T& back() const			{ RDE_ASSERT(!empty()); return upcast(m_root.prev)->value; }
 
 	void push_front(const T& value)
 	{
@@ -216,7 +216,7 @@ public:
 	}
 
 	template<class InputIterator>
-	void assign(InputIterator first, InputIterator last) 
+	void assign(InputIterator first, InputIterator last)
 	{
 		clear();
 		while (first != last)

--- a/map.h
+++ b/map.h
@@ -8,9 +8,12 @@
 
 namespace rde
 {
-template<typename Tk, typename Tv, 
-	class TAllocator = rde::allocator>
-class map 
+template<
+	typename TKey,
+	typename TValue,
+	class TAllocator = rde::allocator
+>
+class map
 {
 	template<typename TNodePtr, typename TPtr, typename TRef>
 	class node_iterator
@@ -19,12 +22,14 @@ class map
 		typedef forward_iterator_tag	iterator_category;
 
 		explicit node_iterator(TNodePtr node, const map* map_)
-		:	m_node(node),
+			: m_node(node),
 			m_map(map_)
-		{/**/}
+		{
+			/**/
+		}
 		template<typename UNodePtr, typename UPtr, typename URef>
 		node_iterator(const node_iterator<UNodePtr, UPtr, URef>& rhs)
-		:	m_node(rhs.node()),
+			: m_node(rhs.node()),
 			m_map(rhs.get_map())
 		{
 			/**/
@@ -44,13 +49,13 @@ class map
 			return m_node;
 		}
 
-		node_iterator& operator++() 
+		node_iterator& operator++()
 		{
 			RDE_ASSERT(m_node != 0);
 			TNodePtr next = find_next_node(m_node);
 			m_node = next;
 			return *this;
-		} 
+		}
 		node_iterator operator++(int)
 		{
 			node_iterator copy(*this);
@@ -77,39 +82,41 @@ class map
 		TNodePtr	m_node;
 		const map*	m_map;
 	};
-	template<typename Tkm, typename Tvm>
-	struct map_pair : public rde::pair<Tkm, Tvm>
+
+	template<typename TKeym, typename TValuem>
+	struct map_pair: public rde::pair<TKeym, TValuem>
 	{
 		map_pair() {}
-		map_pair(const Tkm& k, const Tvm& v): pair<Tkm, Tvm>(k, v) {}
+		map_pair(const TKeym& k, const TValuem& v): pair<TKeym, TValuem>(k, v) {}
 		bool operator<(const map_pair& rhs) const
 		{
 			return first < rhs.first;
 		}
-		RDE_FORCEINLINE const Tkm& get_key() const	{ return first; }
+		RDE_FORCEINLINE const TKeym& get_key() const	{ return first; }
 	};
-	template<typename Tkm, typename Tvm>
+
+	template<typename TKeym, typename TValuem>
 	struct map_traits
 	{
-		typedef	Tkm					key_type;
-		typedef map_pair<Tkm, Tvm>	value_type;
+		typedef	TKeym						key_type;
+		typedef map_pair<TKeym, TValuem>	value_type;
 	};
 
 public:
-	typedef Tk															key_type;
-	typedef Tv															data_type;
-	typedef map_pair<Tk, Tv>											value_type;
-	typedef rb_tree_base<map_traits<Tk, Tv> >							tree_type;
-	typedef typename tree_type::size_type								size_type;
-	typedef node_iterator<typename tree_type::node*, value_type*, value_type&>	iterator;
+	typedef TKey																			key_type;
+	typedef TValue																			data_type;
+	typedef map_pair<TKey, TValue>															value_type;
+	typedef rb_tree_base<map_traits<TKey, TValue> >											tree_type;
+	typedef typename tree_type::size_type													size_type;
+	typedef node_iterator<typename tree_type::node*, value_type*, value_type&>				iterator;
 	typedef node_iterator<typename tree_type::node*, const value_type*, const value_type&>	const_iterator;
-	typedef TAllocator													allocator_type;
+	typedef TAllocator																		allocator_type;
 
 	explicit map(const allocator_type& allocator = allocator_type())
-	:	m_tree(allocator) {}
+		: m_tree(allocator) {}
 	template<typename TInputIterator>
 	map(TInputIterator dataBegin, TInputIterator dataEnd, const allocator_type& allocator = allocator_type())
-	:	m_tree(allocator)
+		: m_tree(allocator)
 	{
 		TInputIterator it = dataBegin;
 		while (it != dataEnd)
@@ -131,7 +138,7 @@ public:
 	{
 		typename tree_type::node* n = m_tree.find_node(key);
 		if (n == 0)
-			n = m_tree.insert(value_type(key, Tv()));
+			n = m_tree.insert(value_type(key, TValue()));
 		return n->value.second;
 	}
 
@@ -162,7 +169,7 @@ private:
 	tree_type	m_tree;
 };
 
-}
+} // namespace rde
 
+//-----------------------------------------------------------------------------
 #endif // RDESTL_MAP_H
-

--- a/pair.h
+++ b/pair.h
@@ -24,44 +24,46 @@ struct pair
 	typedef T1	first_type;
 	typedef T2	second_type;
 
-	pair() {/**/}
-	pair(const T1& a, const T2& b):	first(a), second(b) {/**/}
-	explicit pair(const T1& a):	first(a) {/**/}
+	pair() { /**/ }
+	pair(const T1& a, const T2& b): first(a), second(b) { /**/ }
+	explicit pair(const T1& a): first(a) { /**/ }
 
-    pair(const pair<T1,T2>& rhs) : first(rhs.first), second(rhs.second) {/**/}
-    pair(pair<T1, T2>&& rhs) : first(std::move(rhs.first)), second(std::move(rhs.second)) {/**/ }
+	pair(const pair<T1, T2>& rhs): first(rhs.first), second(rhs.second) { /**/ }
+	pair(pair<T1, T2>&& rhs): first(std::move(rhs.first)), second(std::move(rhs.second)) { /**/ }
 
-    template<class... Args2>
-    pair(T1&& first_args,
-        Args2&&... second_args)
-        :   first(std::forward<T1>(first_args)),
-            second(std::forward<Args2>(second_args)...)
-    {
-    }
-    pair& operator=(const pair<T1,T2>& rhs) 
-    {
-        first = rhs.first;
-        second = rhs.second;
-        return *this;
-    }
-    pair& operator=(pair<T1, T2>&& rhs)
-    {
-        first = std::move(rhs.first);
-        second = std::move(rhs.second);
-        return *this;
-    }
-    
+	template<class... Args2>
+	pair(T1&& first_args,
+		Args2&&... second_args)
+		: first(std::forward<T1>(first_args)),
+		second(std::forward<Args2>(second_args)...)
+	{
+	}
+	pair& operator=(const pair<T1, T2>& rhs)
+	{
+		first = rhs.first;
+		second = rhs.second;
+		return *this;
+	}
+	pair& operator=(pair<T1, T2>&& rhs)
+	{
+		first = std::move(rhs.first);
+		second = std::move(rhs.second);
+		return *this;
+	}
+
 	T1	first;
 	T2	second;
 };
-#endif
+#endif // #ifdef RDESTL_USE_STD_PAIR
 
 //=============================================================================
 // Pair is POD if every element is POD/fundamental
 template<typename T1, typename T2> struct is_pod<pair<T1, T2> >
 {
-	enum { value = (is_pod<T1>::value || is_fundamental<T1>::value) && 
-		(is_pod<T2>::value || is_fundamental<T2>::value) };
+	enum {
+		value = (is_pod<T1>::value || is_fundamental<T1>::value) &&
+		(is_pod<T2>::value || is_fundamental<T2>::value)
+	};
 };
 
 //-----------------------------------------------------------------------------
@@ -71,7 +73,7 @@ pair<T1, T2> make_pair(const T1& a, const T2& b)
 	return pair<T1, T2>(a, b);
 }
 
-}
+} // namespace rde
 
 //-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_PAIR_H

--- a/radix_sorter.h
+++ b/radix_sorter.h
@@ -108,7 +108,7 @@ public:
 		if (num > m_dst.size())
 			resize(num);
 		sort<TDataType, TFunc>(src, num, func, m_dst.begin());
-	}		
+	}
 
 private:
 	void resize(int num)
@@ -117,7 +117,7 @@ private:
 	}
 	void calculate_offsets(uint32* histogram)
 	{
-		uint32 offsets[4] = { 1, 1, 1, 1 };
+		uint32 offsets[4] ={ 1, 1, 1, 1 };
 		for (int i = 0; i < kHistogramSize; ++i)
 		{
 			uint32 temp = histogram[i] + offsets[0];
@@ -139,7 +139,7 @@ private:
 	}
 	void calculate_offsets_signed(uint32* histogram)
 	{
-		uint32 offsets[4] = { 1, 1, 1, 1 };
+		uint32 offsets[4] ={ 1, 1, 1, 1 };
 		int numNeg(0);
 		for (int i = 0; i < kHistogramSize; ++i)
 		{
@@ -176,6 +176,8 @@ private:
 	}
 	vector<T>	m_dst;
 };
-}
 
-#endif
+} // namespace rde
+
+//-----------------------------------------------------------------------------
+#endif // #ifndef RDESTL_RADIX_SORTER_H

--- a/rb_tree.h
+++ b/rb_tree.h
@@ -17,6 +17,7 @@ struct rb_tree_base
 		black
 	};
 };
+
 template<typename TKey>
 struct rb_tree_key_wrapper
 {
@@ -25,6 +26,7 @@ struct rb_tree_key_wrapper
 	rb_tree_key_wrapper(const TKey& key_): key(key_) {}
 	const TKey& get_key() const { return key; }
 };
+
 template<typename TKey>
 struct rb_tree_traits
 {
@@ -32,10 +34,10 @@ struct rb_tree_traits
 	typedef rb_tree_key_wrapper<TKey>	value_type;
 };
 
-} // internal
+} // namespace internal
 
 template<class TTreeTraits, class TAllocator = rde::allocator>
-class rb_tree_base : public internal::rb_tree_base
+class rb_tree_base: public internal::rb_tree_base
 {
 public:
 	typedef typename TTreeTraits::key_type		key_type;
@@ -46,7 +48,7 @@ public:
 	{
 		node() {}
 		node(color_e color_, node* left_, node* right_, node* parent_)
-		:	left(left_), parent(parent_), right(right_), color(color_)
+			: left(left_), parent(parent_), right(right_), color(color_)
 		{
 		}
 
@@ -58,7 +60,7 @@ public:
 	};
 
 	explicit rb_tree_base(const allocator_type& allocator = allocator_type())
-	:	m_size(0),
+		: m_size(0),
 		m_allocator(allocator)
 	{
 		ms_sentinel.color	= black;
@@ -111,7 +113,7 @@ public:
 		return new_node;
 	}
 
-	node* find_node(const key_type& key) 
+	node* find_node(const key_type& key)
 	{
 		node* iter(m_root);
 		while (iter != &ms_sentinel)
@@ -308,7 +310,7 @@ public:
 					grandparent->color = red;
 					iter = grandparent;
 				}
-				else 
+				else
 				{
 					if (iter == iter->parent->right)
 					{
@@ -530,12 +532,13 @@ typename rb_tree_base<TTreeTraits, TAllocator>::node rb_tree_base<TTreeTraits, T
 	internal::rb_tree_base::black, &ms_sentinel, &ms_sentinel, &ms_sentinel);
 
 template<typename TKey, class TAllocator = rde::allocator>
-class rb_tree : public rb_tree_base<internal::rb_tree_traits<TKey>, TAllocator>
+class rb_tree: public rb_tree_base<internal::rb_tree_traits<TKey>, TAllocator>
 {
 public:
 	explicit rb_tree(TAllocator allocator = TAllocator()): rb_tree_base(allocator) {}
 };
 
-} // rde
+} // namespace rde
 
+//-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_RB_TREE_H

--- a/rde_string.h
+++ b/rde_string.h
@@ -11,18 +11,19 @@ typedef basic_string<char>	string;
 template<typename E, class TAllocator, typename TStorage>
 struct hash<basic_string<E, TAllocator, TStorage> >
 {
-    hash_value_t operator()(const basic_string<E, TAllocator, TStorage>& x) const 
-    {
-        // Derived from: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/142054
-        hash_value_t h = 0;
-		for (typename basic_string<E, TAllocator, TStorage>::size_type p = 0; p < x.length(); ++p) 
+	hash_value_t operator()(const basic_string<E, TAllocator, TStorage>& x) const
+	{
+		// Derived from: http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/142054
+		hash_value_t h = 0;
+		for (typename basic_string<E, TAllocator, TStorage>::size_type p = 0; p < x.length(); ++p)
 		{
-            h = x[p] + (h<<6) + (h<<16) - h;
-        }
-        return h & 0x7FFFFFFF;
-    }
+			h = x[p] + (h<<6) + (h<<16) - h;
+		}
+		return h & 0x7FFFFFFF;
+	}
 };
 
-}
+} // namespace rde
 
+//-----------------------------------------------------------------------------
 #endif // RDESTL_STRING_H

--- a/rdestl.code-workspace
+++ b/rdestl.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/rdestl.h
+++ b/rdestl.h
@@ -16,11 +16,17 @@
 
 namespace rde
 {
-    template<typename T, class TAllocator = rde::allocator,
-                class TStorage = standard_vector_storage<T, TAllocator> >
-    struct deque : public vector<T,TAllocator,TStorage>
-    {
-        // TODO
-    };
+template<
+	typename T,
+	class TAllocator = rde::allocator,
+	class TStorage = standard_vector_storage<T, TAllocator>
+>
+struct deque: public vector<T, TAllocator, TStorage>
+{
+	// TODO
 };
-#endif
+
+} // namespace rde
+
+//-----------------------------------------------------------------------------
+#endif // #ifndef RDESTL_H

--- a/rdestl_common.h
+++ b/rdestl_common.h
@@ -6,17 +6,18 @@
 #endif
 
 #if RDESTL_STANDALONE
-#  ifdef _MSC_VER
-#   define _ALLOW_RTCc_IN_STL
-#	include <cassert>
-#	include <cstring>
-#	define RDE_FORCEINLINE	__forceinline
-#  else
-#   include <assert.h>
-#   include <cstdlib>
-#   include <cstring>
-#	define RDE_FORCEINLINE	inline
-#  endif
+
+#	ifdef _MSC_VER
+#		define _ALLOW_RTCc_IN_STL
+#		include <cassert>
+#		include <cstring>
+#		define RDE_FORCEINLINE	__forceinline
+#	else
+#		include <assert.h>
+#		include <cstdlib>
+#		include <cstring>
+#		define RDE_FORCEINLINE	inline
+#	endif
 
 #	ifdef _DEBUG
 #		undef RDE_DEBUG
@@ -28,39 +29,41 @@
 // NOOB
 #include <cstdint>
 
-	namespace rde 
-	{ 
-		// # Meh. MSVC doesnt seem to have <stdint.h>
-		// @todo	Fixes to make this portable.
-		typedef unsigned char		uint8;
-		typedef unsigned short		uint16;
-		typedef signed long			int32;
-		typedef unsigned long		uint32;
-        #ifdef _MSC_VER
-		typedef unsigned __int64	uint64;
-        #else
-        typedef unsigned long long	uint64;
-        #endif
-		namespace Sys 
+namespace rde
+{
+	// # Meh. MSVC doesnt seem to have <stdint.h>
+	// @todo	Fixes to make this portable.
+	typedef unsigned char		uint8;
+	typedef unsigned short		uint16;
+	typedef signed long			int32;
+	typedef unsigned long		uint32;
+	#ifdef _MSC_VER
+	typedef unsigned __int64	uint64;
+	#else
+	typedef unsigned long long	uint64;
+	#endif
+
+	namespace Sys
+	{
+		RDE_FORCEINLINE void MemCpy(void* to, const void* from, size_t bytes)
 		{
-			RDE_FORCEINLINE void MemCpy(void* to, const void* from, size_t bytes)
-			{
-				std::memcpy(to, from, bytes);
-			}
-			RDE_FORCEINLINE void MemMove(void* to, const void* from, size_t bytes)
-			{
-				std::memmove(to, from, bytes);
-			}
-			RDE_FORCEINLINE void MemSet(void* buf, unsigned char value, size_t bytes)
-			{
-				std::memset(buf, value, bytes);
-			}
-		} // sys
-	}
-#else
+			std::memcpy(to, from, bytes);
+		}
+		RDE_FORCEINLINE void MemMove(void* to, const void* from, size_t bytes)
+		{
+			std::memmove(to, from, bytes);
+		}
+		RDE_FORCEINLINE void MemSet(void* buf, unsigned char value, size_t bytes)
+		{
+			std::memset(buf, value, bytes);
+		}
+	} // namespace sys
+} // namespace rde
+
+#else // #if RDESTL_STANDALONE
 #	include "core/RdeAssert.h"
 #	include "core/System.h"
-#endif
+#endif // #if RDESTL_STANDALONE
 
 namespace rde
 {
@@ -68,6 +71,8 @@ enum e_noinitialize
 {
 	noinitialize
 };
-}
 
-#endif // #ifndef RDESTL_H
+} // namespace rde
+
+//-----------------------------------------------------------------------------
+#endif // #ifndef RDESTL_COMMON_H

--- a/rhash.h
+++ b/rhash.h
@@ -3,16 +3,15 @@
 
 namespace rde
 {
-
 typedef unsigned long	hash_value_t;
-    
+
 // Default implementations, just casts to hash_value.
 template<typename T>
 hash_value_t extract_int_key_value(const T& t)
 {
 	return (hash_value_t)t;
 }
- 
+
 // Default implementation of hasher.
 // Works for keys that can be converted to 32-bit integer
 // with extract_int_key_value.
@@ -24,16 +23,17 @@ struct hash
 	hash_value_t operator()(const T& t) const
 	{
 		hash_value_t a = extract_int_key_value(t);
-        a = (a+0x7ed55d16) + (a<<12);
-        a = (a^0xc761c23c) ^ (a>>19);
-        a = (a+0x165667b1) + (a<<5);
-        a = (a+0xd3a2646c) ^ (a<<9);
-        a = (a+0xfd7046c5) + (a<<3);
-        a = (a^0xb55a4f09) ^ (a>>16);
-        return a;
+		a = (a+0x7ed55d16) + (a<<12);
+		a = (a^0xc761c23c) ^ (a>>19);
+		a = (a+0x165667b1) + (a<<5);
+		a = (a+0xd3a2646c) ^ (a<<9);
+		a = (a+0xfd7046c5) + (a<<3);
+		a = (a^0xb55a4f09) ^ (a>>16);
+		return a;
 	}
 };
 
-}
+} // namespace rde
 
-#endif
+//-----------------------------------------------------------------------------
+#endif // #ifndef RDESTL_HASH_H

--- a/set.h
+++ b/set.h
@@ -6,12 +6,14 @@
 
 namespace rde
 {
-template<typename T,
-	class TAllocator = rde::allocator>
-class set : private rb_tree<T, TAllocator>
+template<
+	typename T,
+	class TAllocator = rde::allocator
+>
+class set: private rb_tree<T, TAllocator>
 {
 	typedef rb_tree<T, TAllocator>  Base;
-    typedef typename Base::node     BaseNode;
+	typedef typename Base::node     BaseNode;
 
 	template<typename TNodePtr, typename TPtr, typename TRef>
 	class node_iterator
@@ -20,12 +22,14 @@ class set : private rb_tree<T, TAllocator>
 		typedef forward_iterator_tag	iterator_category;
 
 		explicit node_iterator(TNodePtr node, set* set_)
-		:	m_node(node),
+			: m_node(node),
 			m_set(set_)
-		{/**/}
+		{
+			/**/
+		}
 		template<typename UNodePtr, typename UPtr, typename URef>
 		node_iterator(const node_iterator<UNodePtr, UPtr, URef>& rhs)
-		:	m_node(rhs.node()),
+			: m_node(rhs.node()),
 			m_set(rhs.get_set())
 		{
 			/**/
@@ -45,7 +49,7 @@ class set : private rb_tree<T, TAllocator>
 			return m_node;
 		}
 
-		node_iterator& operator++() 
+		node_iterator& operator++()
 		{
 			RDE_ASSERT(m_node != 0);
 			TNodePtr next = m_node->next;
@@ -53,7 +57,7 @@ class set : private rb_tree<T, TAllocator>
 				next = find_next_node(m_node);
 			m_node = next;
 			return *this;
-		} 
+		}
 		node_iterator operator++(int)
 		{
 			node_iterator copy(*this);
@@ -82,13 +86,13 @@ class set : private rb_tree<T, TAllocator>
 	};
 
 public:
-	typedef T															value_type;
+	typedef T																value_type;
 	typedef node_iterator<BaseNode*, value_type*, value_type&>				iterator;
 	typedef node_iterator<BaseNode*, const value_type*, const value_type&>	const_iterator;
-	typedef TAllocator													allocator_type;
+	typedef TAllocator														allocator_type;
 
 	explicit set(const allocator_type& allocator = allocator_type())
-	:	Base(allocator) {}
+		: Base(allocator) {}
 
 	iterator begin()
 	{
@@ -107,9 +111,9 @@ public:
 		return iterator(0, this);
 	}
 
-	iterator find(const value_type& v)	
-	{ 
-		return iterator(Base::find_node(v), this); 
+	iterator find(const value_type& v)
+	{
+		return iterator(Base::find_node(v), this);
 	}
 	const_iterator find(const value_type& v) const
 	{
@@ -130,6 +134,7 @@ public:
 	using Base::size;
 };
 
-} // rde
+} // namespace rde
 
-#endif // 
+//-----------------------------------------------------------------------------
+#endif // #ifndef RDESTL_SET_H

--- a/simple_string_storage.h
+++ b/simple_string_storage.h
@@ -11,16 +11,16 @@ public:
 	typedef int					size_type;
 	typedef TAllocator			allocator_type;
 	typedef const value_type*	const_iterator;
-	static const unsigned long	kGranularity = 32;	
+	static const unsigned long	kGranularity = 32;
 
 	explicit simple_string_storage(const allocator_type& allocator)
-	:	m_length(0),
+		: m_length(0),
 		m_allocator(allocator)
 	{
 		m_data = construct_string(0, m_capacity);
 	}
 	simple_string_storage(const value_type* str, const allocator_type& allocator)
-	:	m_allocator(allocator)
+		: m_allocator(allocator)
 	{
 		const int len = strlen(str);
 		m_data = construct_string(len, m_capacity);
@@ -28,9 +28,9 @@ public:
 		m_length = len;
 		m_data[len] = 0;
 	}
-	simple_string_storage(const value_type* str, size_type len, 
+	simple_string_storage(const value_type* str, size_type len,
 		const allocator_type& allocator)
-	:	m_allocator(allocator)
+		: m_allocator(allocator)
 	{
 		m_data = construct_string(len, m_capacity);
 		Sys::MemCpy(m_data, str, len*sizeof(value_type));
@@ -38,28 +38,28 @@ public:
 		m_data[len] = 0;
 	}
 	simple_string_storage(const simple_string_storage& rhs, const allocator_type& allocator)
-	:	m_data(0),
-		m_capacity(0), 
+		: m_data(0),
+		m_capacity(0),
 		m_length(0),
 		m_allocator(allocator)
 	{
 		assign(rhs.c_str(), rhs.length());
 	}
-	~simple_string_storage()	
+	~simple_string_storage()
 	{
 		release_string();
 	}
 
 	// @note: doesnt copy allocator
-    simple_string_storage& operator=(const simple_string_storage& rhs)
+	simple_string_storage& operator=(const simple_string_storage& rhs)
 	{
-		if (m_data != rhs.c_str()) 
+		if (m_data != rhs.c_str())
 		{
 			assign(rhs.c_str(), rhs.length());
 		}
 		return *this;
 	}
-        
+
 	void assign(const value_type* str, size_type len)
 	{
 		// Do not use with str = str.c_str()!
@@ -84,7 +84,7 @@ public:
 			value_type* newData = construct_string(newLen, newCapacity);
 			Sys::MemCpy(newData, m_data, prevLen * sizeof(value_type));
 			release_string();
-            m_data = newData;
+			m_data = newData;
 			m_capacity = newCapacity;
 		}
 		Sys::MemCpy(m_data + prevLen, str, len * sizeof(value_type));
@@ -97,21 +97,21 @@ public:
 	{
 		return m_data;
 	}
-	
-    inline size_type length() const
+
+	inline size_type length() const
 	{
 		return m_length;
 	}
-    
-    inline size_type capacity() const { return m_capacity; }
-    
-    void clear() 
-    {
-        release_string();
-        m_data = construct_string(0, m_capacity);
-        m_length = 0;
-    }
-    
+
+	inline size_type capacity() const { return m_capacity; }
+
+	void clear()
+	{
+		release_string();
+		m_data = construct_string(0, m_capacity);
+		m_length = 0;
+	}
+
 	const allocator_type& get_allocator() const	{ return m_allocator; }
 
 	void make_unique(size_type) {}
@@ -128,23 +128,23 @@ protected:
 	}
 private:
 	value_type* construct_string(size_type capacity, size_type& out_capacity)
-	{  
-        value_type* data(0);
-        if (capacity != 0)
-        {
-            capacity = (capacity+kGranularity-1) & ~(kGranularity-1);
-            if (capacity < kGranularity)
-                capacity = kGranularity;
+	{
+		value_type* data(0);
+		if (capacity != 0)
+		{
+			capacity = (capacity+kGranularity-1) & ~(kGranularity-1);
+			if (capacity < kGranularity)
+				capacity = kGranularity;
 
-            const size_type toAlloc = sizeof(value_type)*(capacity + 1);
-            void* mem = m_allocator.allocate(toAlloc);
-            data = static_cast<value_type*>(mem);
-        }
-        else	// empty string, no allocation needed. Use our internal buffer.
-        {
-            data = &m_end_of_data;
-        }
-    
+			const size_type toAlloc = sizeof(value_type)*(capacity + 1);
+			void* mem = m_allocator.allocate(toAlloc);
+			data = static_cast<value_type*>(mem);
+		}
+		else	// empty string, no allocation needed. Use our internal buffer.
+		{
+			data = &m_end_of_data;
+		}
+
 		out_capacity = capacity;
 		*data = 0;
 		return data;
@@ -157,7 +157,7 @@ private:
 			m_allocator.deallocate(m_data, m_capacity);
 		}
 	}
-    
+
 	E*			m_data;
 	E			m_end_of_data;
 	size_type	m_capacity;
@@ -165,6 +165,7 @@ private:
 	TAllocator	m_allocator;
 };
 
-} // rde
+} // namespace rde
 
+//-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_SIMPLE_STRING_STORAGE_H

--- a/slist.cpp
+++ b/slist.cpp
@@ -2,20 +2,21 @@
 
 namespace rde
 {
-	namespace internal
+namespace internal
+{
+	void slist_base_node::link_after(slist_base_node* prevNode)
 	{
-		void slist_base_node::link_after(slist_base_node* prevNode)
-		{
-			RDE_ASSERT(!in_list());
-			next = prevNode->next;
-			prevNode->next = this;
-		}
-		void slist_base_node::unlink(slist_base_node* prevNode)
-		{
-			RDE_ASSERT(in_list());
-			RDE_ASSERT(prevNode->next == this);
-			prevNode->next = next;
-			next = this;
-		}
+		RDE_ASSERT(!in_list());
+		next = prevNode->next;
+		prevNode->next = this;
 	}
-}
+	void slist_base_node::unlink(slist_base_node* prevNode)
+	{
+		RDE_ASSERT(in_list());
+		RDE_ASSERT(prevNode->next == this);
+		prevNode->next = next;
+		next = this;
+	}
+
+} // namespace internal
+} // namespace rde

--- a/slist.h
+++ b/slist.h
@@ -8,34 +8,34 @@ namespace rde
 {
 namespace internal
 {
-	struct slist_base_node
+struct slist_base_node
+{
+	slist_base_node()
 	{
-		slist_base_node()
-		{
-			reset();
-		}
-		void reset()
-		{
-			next = this;
-		}
-		bool in_list() const { return this != next; }
+		reset();
+	}
+	void reset()
+	{
+		next = this;
+	}
+	bool in_list() const { return this != next; }
 
-		void link_after(slist_base_node* prevNode);
-		void unlink(slist_base_node* prevNode);
+	void link_after(slist_base_node* prevNode);
+	void unlink(slist_base_node* prevNode);
 
-		slist_base_node*	next;
-	};
-}
+	slist_base_node*	next;
+};
+} // namespace internal
 
 //=============================================================================
 template<typename T, class TAllocator = rde::allocator>
 class slist
 {
-	private:
-	struct node : public internal::slist_base_node
+private:
+	struct node: public internal::slist_base_node
 	{
-		node():	internal::slist_base_node() {}
-		explicit node(const T& v): internal::slist_base_node(),	value(v) {}
+		node(): internal::slist_base_node() {}
+		explicit node(const T& v): internal::slist_base_node(), value(v) {}
 		T		value;
 	};
 	static RDE_FORCEINLINE node* upcast(internal::slist_base_node* n)
@@ -48,10 +48,10 @@ class slist
 	public:
 		typedef forward_iterator_tag	iterator_category;
 
-		explicit node_iterator(TNodePtr node):	m_node(node) {/**/}
+		explicit node_iterator(TNodePtr node): m_node(node) { /**/ }
 		template<typename UNodePtr, typename UPtr, typename URef>
 		node_iterator(const node_iterator<UNodePtr, UPtr, URef>& rhs)
-		:	m_node(rhs.node())
+			: m_node(rhs.node())
 		{
 			/**/
 		}
@@ -73,7 +73,7 @@ class slist
 		{
 			return upcast(m_node->next);
 		}
-		
+
 		node_iterator& operator++()
 		{
 			m_node = upcast(m_node->next);
@@ -108,20 +108,20 @@ public:
 	static const std::size_t									kNodeSize = sizeof(node);
 
 	explicit slist(const allocator_type& allocator = allocator_type())
-	:	m_allocator(allocator)
+		: m_allocator(allocator)
 	{
 		m_root.reset();
 	}
 	template<class InputIterator>
-	slist(InputIterator first, InputIterator last, 
+	slist(InputIterator first, InputIterator last,
 		const allocator_type& allocator = allocator_type())
-	:	m_allocator(allocator)
+		: m_allocator(allocator)
 	{
 		m_root.reset();
 		assign(first, last);
 	}
 	slist(const slist& rhs, const allocator_type& allocator = allocator_type())
-	:	m_allocator(allocator)
+		: m_allocator(allocator)
 	{
 		m_root.reset();
 		assign(rhs.begin(), rhs.end());
@@ -167,7 +167,7 @@ public:
 	}
 
 	template<class InputIterator>
-	void assign(InputIterator first, InputIterator last) 
+	void assign(InputIterator first, InputIterator last)
 	{
 		clear();
 		iterator it(&m_root);
@@ -190,7 +190,7 @@ public:
 			it = nextIt;
 		}
 		m_root.reset();
-	}	
+	}
 	bool empty() const	{ return !m_root.in_list(); }
 	// @todo: consider keeping size member, would make this O(1)
 	// as a policy? via preprocessor macro? TBD
@@ -224,7 +224,6 @@ public:
 			++prevIt;
 		return prevIt;
 	}
-
 
 private:
 	node* construct_node(const T& value)

--- a/sort.h
+++ b/sort.h
@@ -69,12 +69,12 @@ void down_heap(T* data, size_t k, size_t n, TPredicate pred)
 	data[k - 1] = temp;
 }
 
-} // internal
+} // namespace internal
 
 template<typename T, class TPredicate>
 void insertion_sort(T* begin, T* end, TPredicate pred)
 {
-	const size_t num = end - begin;	
+	const size_t num = end - begin;
 	for (size_t i = 0; i < num; ++i)
 	{
 		const T t = begin[i];
@@ -117,7 +117,7 @@ void heap_sort(T* begin, T* end, TPredicate pred)
 		const T temp = begin[0];
 		begin[0] = begin[n - 1];
 		begin[n - 1] = temp;
-		
+
 		--n;
 		internal::down_heap(begin, 1, n, pred);
 	}
@@ -152,6 +152,7 @@ bool is_sorted(TIter begin, TIter end, TPredicate pred)
 	return is_sorted;
 }
 
-} // rde
+} // namespace rde
 
-#endif 
+//-----------------------------------------------------------------------------
+#endif // #ifndef RDESTL_SORT_H

--- a/sorted_vector.h
+++ b/sorted_vector.h
@@ -11,29 +11,32 @@ namespace rde
 namespace internal
 {
 	//=========================================================================
-	template<class TPair, class TFunctor>
-	struct compare_func
+template<class TPair, class TFunctor>
+struct compare_func
+{
+	bool operator()(const TPair& lhs, const TPair& rhs) const
 	{
-		bool operator()(const TPair& lhs, const TPair& rhs) const
-		{
-			return TFunctor()(lhs.first, rhs.first);
-		}
-		bool operator()(const TPair& lhs, const typename TPair::first_type& rhs) const
-		{
-			return TFunctor()(lhs.first, rhs);
-		}
-		bool operator()(const typename TPair::first_type& lhs, const TPair& rhs) const
-		{
-			return TFunctor()(lhs, rhs.first);
-		}
-	};
-}
+		return TFunctor()(lhs.first, rhs.first);
+	}
+	bool operator()(const TPair& lhs, const typename TPair::first_type& rhs) const
+	{
+		return TFunctor()(lhs.first, rhs);
+	}
+	bool operator()(const typename TPair::first_type& lhs, const TPair& rhs) const
+	{
+		return TFunctor()(lhs, rhs.first);
+	}
+};
+
+} // namespace internal
 
 //=============================================================================
-template<typename TKey, typename TValue, class TCompare = rde::less<TKey>,
-	class TAllocator = rde::allocator, 
-	class TStorage = rde::standard_vector_storage<pair<TKey, TValue>, TAllocator> >
-class sorted_vector : private vector<pair<TKey, TValue>, TAllocator, TStorage >
+template<typename TKey, typename TValue,
+	class TCompare = rde::less<TKey>,
+	class TAllocator = rde::allocator,
+	class TStorage = rde::standard_vector_storage<pair<TKey, TValue>, TAllocator>
+>
+class sorted_vector: private vector<pair<TKey, TValue>, TAllocator, TStorage>
 {
 	typedef vector<pair<TKey, TValue>, TAllocator, TStorage>	Base;
 
@@ -47,14 +50,14 @@ public:
 	typedef typename Base::allocator_type	allocator_type;
 
 	explicit sorted_vector(const allocator_type& allocator = allocator_type())
-	:	Base(allocator)
+		: Base(allocator)
 	{
 		/**/
 	}
 	template <class InputIterator>
-	sorted_vector(InputIterator first, InputIterator last, 
+	sorted_vector(InputIterator first, InputIterator last,
 		const allocator_type& allocator = allocator_type())
-	:	Base(first, last, allocator)
+		: Base(first, last, allocator)
 	{
 		rde::quick_sort(begin(), end(), m_compare);
 		RDE_ASSERT(invariant());
@@ -83,31 +86,30 @@ public:
 		return pair<iterator, bool>(it, !found);
 	}
 	// @extension
-	RDE_FORCEINLINE 
-	pair<iterator, bool> insert(const key_type& k, const mapped_type& v)
+	RDE_FORCEINLINE pair<iterator, bool> insert(const key_type& k, const mapped_type& v)
 	{
 		return insert(value_type(k, v));
 	}
 
 	iterator find(const key_type& k)
-    {
+	{
 		RDE_ASSERT(invariant());
 		iterator i(lower_bound(k));
-        if (i != end() && m_compare(k, *i))
-        {
+		if (i != end() && m_compare(k, *i))
+		{
 			i = end();
 		}
-        return i;
+		return i;
 	}
-    const_iterator find(const key_type& k) const
-    {       
+	const_iterator find(const key_type& k) const
+	{
 		RDE_ASSERT(invariant());
 		const_iterator i(lower_bound(k));
-        if (i != end() && m_compare(k, *i))
-        {
+		if (i != end() && m_compare(k, *i))
+		{
 			i = end();
 		}
-        return i;
+		return i;
 	}
 
 	RDE_FORCEINLINE iterator erase(iterator it)
@@ -116,13 +118,13 @@ public:
 		return Base::erase(it);
 	}
 	size_type erase(const key_type& k)
-    {
+	{
 		iterator i(find(k));
-        if (i == end()) 
+		if (i == end())
 			return 0;
-        erase(i);
+		erase(i);
 		RDE_ASSERT(invariant());
-        return 1;
+		return 1;
 	}
 
 	using Base::clear;

--- a/sstream.h
+++ b/sstream.h
@@ -1,5 +1,5 @@
 /**
- by Danushka Abeysuriya aka. 'silvermace' 
+ by Danushka Abeysuriya aka. 'silvermace'
  Contact: silvermace@gmail.com
  Last Edit 18 May 2010
 */
@@ -11,111 +11,116 @@
 #include "rde_string.h"
 #include "vector.h"
 
-namespace rde 
+namespace rde
 {
-    /*
-     this is a super cut down replacement for std::stringstream
-     current limitations:
-     - only converts from string -> primitve type
-     - only supports signed int, signed long, float and rde::string
-     - no support for unsigned word types
-     - untested unicode support, no support for custom allocator
-     */
-    template< typename E, typename TAlloc = rde::allocator >
-    struct basic_stringstream
-    {
-        typedef E                                   value_type;
-        typedef rde::vector<value_type, TAlloc>     buffer_type;
-        typedef typename buffer_type::size_type		size_type;
-		typedef basic_string<value_type, TAlloc>	string_type;
-        
-        explicit basic_stringstream(const value_type* inp) { init(inp); }
-        explicit basic_stringstream(const string_type& inp) { init(inp.c_str()); }
-        basic_stringstream() {}
- 
-        bool good() const { return buffer.size() ? cursor != buffer.end() : false; }
-        bool eof() const { return !good(); }
-        operator bool() const { return good(); }
-        
-        void reset(const value_type* inp) {
-            init(inp);
-        }
-        
-        //------------------------------------------------------
-        //Output operators
-        basic_stringstream& operator>>(int& x) {
-            if( next() ) 
-                x = atoi((const char*)current.c_str());
-            return *this;
-        }
-        basic_stringstream& operator>>(long& x) {
-            if( next() ) 
-                x = atol((const char*)current.c_str());
-            return *this;
-        }
-        basic_stringstream& operator>>(float& x) {
-            if( next() ) 
-                x = atof((const char*)current.c_str());
-            return *this;
-        }
-        basic_stringstream& operator>>(rde::string& x) {
-            if( next() ) 
-                x = current;
-            return *this;
-        }
-        //------------------------------------------------------
-        
-    private:
-        //Setup our data buffer and cursor
-        void init(const value_type* inp) 
-        {
-            if( !inp || !strlen(inp) ) {
-                cursor = buffer.end();
-                return;
-            }
-            const size_type len = strlen(inp);
-            buffer.resize(len);
-            memmove(buffer.begin(), inp, len);
-            cursor = buffer.begin();
-            current.clear();
-            ltrim();
-        }
-        
-        bool is_whitespace(const value_type& ch) const {
-            return (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n');
-        }
-        
-        //Trim whitespace from the left->right
-        void ltrim() {
-            while(is_whitespace(*cursor)) 
-                ++cursor;
-        }
-        
-        //Read in the next token into current
-        bool next() 
-        {
-            if(!buffer.size())
-                return false;
-            current.clear();
-            for(; cursor!=buffer.end(); ++cursor) {
-                if(!is_whitespace(*cursor)) {
-                    current.append(*cursor);   
-                } else {
-                    ltrim();
-                    break;
-                }
-            }
-            return current.length();
-        }
-        
-        //Data members
-        string_type current;
-        buffer_type buffer;
-        typename buffer_type::const_iterator cursor;
-    };    
-    
-    typedef basic_stringstream<char> stringstream;
-}
+/**
+ * this is a super cut down replacement for std::stringstream
+ * current limitations:
+ * - only converts from string -> primitve type
+ * - only supports signed int, signed long, float and rde::string
+ * - no support for unsigned word types
+ * - untested unicode support, no support for custom allocator
+ */
+template<
+	typename E,
+	typename TAlloc = rde::allocator
+>
+struct basic_stringstream
+{
+	typedef E									value_type;
+	typedef rde::vector<value_type, TAlloc>		buffer_type;
+	typedef typename buffer_type::size_type		size_type;
+	typedef basic_string<value_type, TAlloc>	string_type;
 
+	explicit basic_stringstream(const value_type* inp) { init(inp); }
+	explicit basic_stringstream(const string_type& inp) { init(inp.c_str()); }
+	basic_stringstream() {}
 
-#endif
+	bool good() const 		{ return buffer.size() ? cursor != buffer.end() : false; }
+	bool eof() const 		{ return !good(); }
+	operator bool() const 	{ return good(); }
+
+	void reset(const value_type* inp) {
+		init(inp);
+	}
+
+	//------------------------------------------------------
+	//Output operators
+	basic_stringstream& operator>>(int& x) {
+		if (next())
+			x = atoi((const char*)current.c_str());
+		return *this;
+	}
+	basic_stringstream& operator>>(long& x) {
+		if (next())
+			x = atol((const char*)current.c_str());
+		return *this;
+	}
+	basic_stringstream& operator>>(float& x) {
+		if (next())
+			x = atof((const char*)current.c_str());
+		return *this;
+	}
+	basic_stringstream& operator>>(rde::string& x) {
+		if (next())
+			x = current;
+		return *this;
+	}
+	//------------------------------------------------------
+
+private:
+	//Setup our data buffer and cursor
+	void init(const value_type* inp)
+	{
+		if (!inp || !strlen(inp)) {
+			cursor = buffer.end();
+			return;
+		}
+		const size_type len = strlen(inp);
+		buffer.resize(len);
+		memmove(buffer.begin(), inp, len);
+		cursor = buffer.begin();
+		current.clear();
+		ltrim();
+	}
+
+	bool is_whitespace(const value_type& ch) const {
+		return (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n');
+	}
+
+	//Trim whitespace from the left->right
+	void ltrim() {
+		while (is_whitespace(*cursor))
+			++cursor;
+	}
+
+	//Read in the next token into current
+	bool next()
+	{
+		if (!buffer.size())
+			return false;
+		current.clear();
+		for (; cursor!=buffer.end(); ++cursor) {
+			if (!is_whitespace(*cursor)) {
+				current.append(*cursor);
+			}
+			else {
+				ltrim();
+				break;
+			}
+		}
+		return current.length();
+	}
+
+	//Data members
+	string_type current;
+	buffer_type buffer;
+	typename buffer_type::const_iterator cursor;
+};
+
+typedef basic_stringstream<char>	stringstream;
+
+} // namespace rde
+
+//-----------------------------------------------------------------------------
+#endif // #ifndef RDESTL_STRINGSTREAM_H

--- a/stack.h
+++ b/stack.h
@@ -6,8 +6,11 @@
 namespace rde
 {
 // Stack implemented on top of another container (vector by default).
-template<typename T, class TAllocator = rde::allocator,
-	class TContainer = rde::vector<T, TAllocator> >
+template<
+	typename T,
+	class TAllocator = rde::allocator,
+	class TContainer = rde::vector<T, TAllocator>
+>
 class stack
 {
 public:
@@ -17,15 +20,15 @@ public:
 	typedef TAllocator						allocator_type;
 
 	explicit stack(const allocator_type& allocator = allocator_type())
-	:	m_container(allocator)
+		: m_container(allocator)
 	{
 	}
 	stack(const stack& rhs, const allocator_type& allocator = allocator_type())
-	:	m_container(rhs, allocator)
+		: m_container(rhs, allocator)
 	{
 	}
 	explicit stack(e_noinitialize n)
-	:	m_container(n)
+		: m_container(n)
 	{
 	}
 
@@ -51,14 +54,14 @@ public:
 	const value_type& top() const	{ return m_container.back(); }
 
 	// @extension
-	void clear()			{ m_container.clear(); }
+	void clear()					{ m_container.clear(); }
 
-	bool empty() const		{ return m_container.empty(); }
-	size_type size() const	{ return m_container.size(); }
+	bool empty() const				{ return m_container.empty(); }
+	size_type size() const			{ return m_container.size(); }
 
-	const allocator_type& get_allocator() const	
-	{ 
-		return m_container.get_allocator(); 
+	const allocator_type& get_allocator() const
+	{
+		return m_container.get_allocator();
 	}
 	void set_allocator(const allocator_type& allocator)
 	{
@@ -69,6 +72,7 @@ private:
 	TContainer	m_container;
 };
 
-} // rde
+} // namespace rde
 
-#endif
+//-----------------------------------------------------------------------------
+#endif // #ifndef RDESTL_STACK_H

--- a/stack_allocator.h
+++ b/stack_allocator.h
@@ -15,7 +15,7 @@ class stack_allocator
 {
 public:
 	explicit stack_allocator(const char* name = "STACK")
-	:	m_name(name), 
+		: m_name(name),
 		m_bufferTop(0)
 	{
 		/**/
@@ -34,7 +34,7 @@ public:
 		sizeof(ptr);
 	}
 
-	const char* get_name() const	{ return m_name; }
+	const char* get_name() const { return m_name; }
 
 private:
 	stack_allocator(const stack_allocator&);
@@ -46,5 +46,6 @@ private:
 };
 
 } // namespace rde
+
 //-----------------------------------------------------------------------------
-#endif 
+#endif // #ifndef RDESTL_STACK_ALLOCATOR_H

--- a/string_utils.h
+++ b/string_utils.h
@@ -48,6 +48,7 @@ template<typename T> int strcompare(const T* s1, const T* s2)
 	return 0;
 }
 
-} // rde
+} // namespace rde
 
+//-----------------------------------------------------------------------------
 #endif // RDESTL_STRING_UTILS_H

--- a/type_traits.h
+++ b/type_traits.h
@@ -3,8 +3,7 @@
 
 namespace rde
 {
-
-template<typename T> struct is_integral 
+template<typename T> struct is_integral
 {
 	enum { value = false };
 };
@@ -46,7 +45,7 @@ template<typename T> struct is_pod
 
 template<typename T> struct is_fundamental
 {
-	enum 
+	enum
 	{
 		value = is_integral<T>::value || is_floating_point<T>::value
 	};
@@ -96,4 +95,3 @@ template<typename T> struct has_cheap_compare
 
 //-----------------------------------------------------------------------------
 #endif // #ifndef RDESTL_TYPETRAITS_H
-

--- a/utility.h
+++ b/utility.h
@@ -67,7 +67,7 @@ namespace internal
 		while (--last >= first)
 			*(--result) = *last;
 	}
-	template<typename T> RDE_FORCEINLINE 
+	template<typename T> RDE_FORCEINLINE
 	void move(const T* first, const T* last, T* result, int_to_type<true>)
 	{
 		// Meh, MSVC does pretty stupid things here.
@@ -91,19 +91,19 @@ namespace internal
 		Sys::MemCpy(result, first, n * sizeof(T));
 	}
 
-    template<typename T>
-    void move_construct_n(T* first, size_t n, T* result, int_to_type<false>)
-    {
-        for (size_t i = 0; i < n; ++i)
-            new (result + i) T(std::move(first[i]));
-    }
+	template<typename T>
+	void move_construct_n(T* first, size_t n, T* result, int_to_type<false>)
+	{
+		for (size_t i = 0; i < n; ++i)
+			new (result + i) T(std::move(first[i]));
+	}
 
-    template<typename T>
-    void move_construct_n(T* first, size_t n, T* result, int_to_type<true>)
-    {
-        RDE_ASSERT(result >= first + n || result < first);
-        Sys::MemCpy(result, first, n * sizeof(T));
-    }
+	template<typename T>
+	void move_construct_n(T* first, size_t n, T* result, int_to_type<true>)
+	{
+		RDE_ASSERT(result >= first + n || result < first);
+		Sys::MemCpy(result, first, n * sizeof(T));
+	}
 
 	template<typename T>
 	void destruct_n(T* first, size_t n, int_to_type<false>)
@@ -170,7 +170,7 @@ namespace internal
 	template<class TIter, class TPred>
 	void test_ordering(TIter first, TIter last, const TPred& pred)
 	{
-#if RDE_DEBUG
+	#if RDE_DEBUG
 		if (first != last)
 		{
 			TIter next = first;
@@ -180,15 +180,15 @@ namespace internal
 				first = next;
 			}
 		}
-#else
+	#else
 		sizeof(first); sizeof(last); sizeof(pred);
-#endif
+	#endif
 	}
 
 	template<typename T1, typename T2, class TPred> inline
-	bool debug_pred(const TPred& pred, const T1& a, const T2& b) 
+	bool debug_pred(const TPred& pred, const T1& a, const T2& b)
 	{
-#if RDE_DEBUG
+	#if RDE_DEBUG
 		if (pred(a, b))
 		{
 			RDE_ASSERT(!pred(b, a));
@@ -198,12 +198,12 @@ namespace internal
 		{
 			return false;
 		}
-#else
+	#else
 		return pred(a, b);
-#endif
+	#endif
 	}
-} // namespace internal
 
+} // namespace internal
 } // namespace rde
 
 //-----------------------------------------------------------------------------

--- a/vector.h
+++ b/vector.h
@@ -18,35 +18,35 @@ struct base_vector
 // Standard vector storage.
 // Dynamic allocation, can grow, can shrink.
 template<typename T, class TAllocator>
-struct standard_vector_storage 
+struct standard_vector_storage
 {
 	explicit standard_vector_storage(const TAllocator& allocator)
-	:	m_begin(0),
+		: m_begin(0),
 		m_end(0),
 		m_capacityEnd(0),
 		m_allocator(allocator)
 	{
 		/**/
 	}
-    standard_vector_storage(standard_vector_storage&& rhs)
-    :   m_begin(std::exchange(rhs.m_begin, nullptr)),
-        m_end(std::exchange(rhs.m_end, nullptr)),
-        m_capacityEnd(std::exchange(rhs.m_capacityEnd, nullptr)),
-        m_allocator(std::move(rhs.m_allocator))
-    {
-    }
-	explicit standard_vector_storage(e_noinitialize) 
+	standard_vector_storage(standard_vector_storage&& rhs)
+		: m_begin(std::exchange(rhs.m_begin, nullptr)),
+		m_end(std::exchange(rhs.m_end, nullptr)),
+		m_capacityEnd(std::exchange(rhs.m_capacityEnd, nullptr)),
+		m_allocator(std::move(rhs.m_allocator))
+	{
+	}
+	explicit standard_vector_storage(e_noinitialize)
 	{
 	}
 
-    standard_vector_storage& operator=(standard_vector_storage&& rhs)
-    {
-        m_begin = std::exchange(rhs.m_begin, nullptr);
-        m_end = std::exchange(rhs.m_end, nullptr);
-        m_capacityEnd = std::exchange(rhs.m_capacityEnd, nullptr);
-        m_allocator = std::move(rhs.m_allocator);
-        return *this;
-    }
+	standard_vector_storage& operator=(standard_vector_storage&& rhs)
+	{
+		m_begin = std::exchange(rhs.m_begin, nullptr);
+		m_end = std::exchange(rhs.m_end, nullptr);
+		m_capacityEnd = std::exchange(rhs.m_capacityEnd, nullptr);
+		m_allocator = std::move(rhs.m_allocator);
+		return *this;
+	}
 
 	void reallocate(base_vector::size_type newCapacity, base_vector::size_type oldSize)
 	{
@@ -108,47 +108,50 @@ struct standard_vector_storage
 //=============================================================================
 // Simplified vector class.
 // Mimics std::vector.
-template<typename T, class TAllocator = rde::allocator,
-	class TStorage = standard_vector_storage<T, TAllocator> >
-class vector : public base_vector, private TStorage
+template<
+	typename T,
+	class TAllocator = rde::allocator,
+	class TStorage = standard_vector_storage<T, TAllocator>
+>
+class vector: public base_vector, private TStorage
 {
 private:
-    using TStorage::m_begin;
-    using TStorage::m_end;
-    using TStorage::m_capacityEnd;
-    using TStorage::m_allocator;
-    using TStorage::invariant;
-    using TStorage::reallocate;
-    
+	using TStorage::m_begin;
+	using TStorage::m_end;
+	using TStorage::m_capacityEnd;
+	using TStorage::m_allocator;
+	using TStorage::invariant;
+	using TStorage::reallocate;
+
 public:
 	typedef T				value_type;
 	typedef T*				iterator;
 	typedef const T*		const_iterator;
 	typedef TAllocator		allocator_type;
 	static const size_type	kInitialCapacity = 16;
-   
+
 	explicit vector(const allocator_type& allocator = allocator_type())
-	:	TStorage(allocator)
+		: TStorage(allocator)
 	{
 		/**/
 	}
 	explicit vector(size_type initialSize, const allocator_type& allocator = allocator_type())
-	:	TStorage(allocator)
+		: TStorage(allocator)
 	{
 		resize(initialSize);
 	}
 	vector(const T* first, const T* last, const allocator_type& allocator = allocator_type())
-	:	TStorage(allocator)
+		: TStorage(allocator)
 	{
 		assign(first, last);
 	}
 	// @note: allocator is not copied from rhs.
 	// @note: will not perform default constructor for newly created objects.
 	vector(const vector& rhs, const allocator_type& allocator = allocator_type())
-	:	TStorage(allocator)
+		: TStorage(allocator)
 	{
-        if(rhs.size() == 0) // nothing to do
-            return;
+		if (rhs.size() == 0) // nothing to do
+			return;
 		this->reallocate_discard_old(rhs.capacity());
 		rde::copy_construct_n(rhs.m_begin, rhs.size(), m_begin);
 		m_end = m_begin + rhs.size();
@@ -156,13 +159,13 @@ public:
 		RDE_ASSERT(invariant());
 	}
 	explicit vector(e_noinitialize n)
-	:	TStorage(n)
+		: TStorage(n)
 	{
 	}
-    vector(vector&& rhs)
-    :   TStorage(std::forward<TStorage&&>(rhs))
-    {
-    }
+	vector(vector&& rhs)
+		: TStorage(std::forward<TStorage&&>(rhs))
+	{
+	}
 	~vector()
 	{
 		if (TStorage::m_begin != 0)
@@ -174,21 +177,21 @@ public:
 	//			just initialize with copy ctor of elements of rhs.
 	vector& operator=(const vector& rhs)
 	{
-        copy(rhs);		
+		copy(rhs);
 		return *this;
 	}
-    vector& operator=(vector&& rhs)
-    {
-        if (&rhs == this)
-        {
-            return *this;
-        }
-        TStorage::operator=(std::forward<TStorage&&>(rhs));
-        return *this;
-    }
-    
-    void copy(const vector& rhs)
-    {
+	vector& operator=(vector&& rhs)
+	{
+		if (&rhs == this)
+		{
+			return *this;
+		}
+		TStorage::operator=(std::forward<TStorage&&>(rhs));
+		return *this;
+	}
+
+	void copy(const vector& rhs)
+	{
 		const size_type newSize = rhs.size();
 		if (newSize > capacity())
 		{
@@ -198,7 +201,7 @@ public:
 		m_end = m_begin + newSize;
 		TStorage::record_high_watermark();
 		RDE_ASSERT(invariant());
-    }
+	}
 
 	// @note: swap() not provided for the time being.
 
@@ -234,28 +237,28 @@ public:
 		return *(end() - 1);
 	}
 
-	T& operator[](size_type i) 
-    {
+	T& operator[](size_type i)
+	{
 		return at(i);
 	}
 
-	const T& operator[](size_type i) const 
-    {
-        return at(i);
+	const T& operator[](size_type i) const
+	{
+		return at(i);
 	}
 
-    T& at(size_type i) 
-    {
-        RDE_ASSERT(i < size());
+	T& at(size_type i)
+	{
+		RDE_ASSERT(i < size());
 		return m_begin[i];
-    }
+	}
 
-    const T& at(size_type i) const
-    {
-        RDE_ASSERT(i < size());
+	const T& at(size_type i) const
+	{
+		RDE_ASSERT(i < size());
 		return m_begin[i];
-    }
-    
+	}
+
 	void push_back(const T& v)
 	{
 		if (m_end < m_capacityEnd)
@@ -285,17 +288,17 @@ public:
 		rde::destruct(m_end);
 	}
 
-    template<class... Args>
-    void emplace_back(Args&&... args)
-    {
-        if (m_end == m_capacityEnd)
-        {
-            grow();
-        }
-        rde::construct_args(m_end, std::forward<Args>(args)...);
-        ++m_end;
-        TStorage::record_high_watermark();
-    }
+	template<class... Args>
+	void emplace_back(Args&&... args)
+	{
+		if (m_end == m_capacityEnd)
+		{
+			grow();
+		}
+		rde::construct_args(m_end, std::forward<Args>(args)...);
+		++m_end;
+		TStorage::record_high_watermark();
+	}
 
 	void assign(const T* first, const T* last)
 	{
@@ -347,7 +350,7 @@ public:
 			for (size_type i = 0; i < n; ++i)
 				insertPos[i] = val;
 		}
-		m_end += n; 
+		m_end += n;
 		TStorage::record_high_watermark();
 	}
 	// @pre validate_iterator(it)
@@ -377,7 +380,7 @@ public:
 		// @note: conditional vs empty loop, what's better?
 		if (m_end > it)
 		{
-			if(!has_trivial_copy<T>::value)
+			if (!has_trivial_copy<T>::value)
 			{
 				const size_type prevSize = size();
 				RDE_ASSERT(index <= prevSize);
@@ -423,7 +426,7 @@ public:
 		RDE_ASSERT(invariant());
 		if (last <= first)
 			return end();
-		
+
 		const size_type indexFirst = size_type(first - m_begin);
 		const size_type toRemove = size_type(last - first);
 		if (toRemove > 0)
@@ -458,7 +461,7 @@ public:
 	}
 	void reserve(size_type n)
 	{
-		if (n > capacity())			
+		if (n > capacity())
 			reallocate(n, size());
 	}
 
@@ -487,7 +490,7 @@ public:
 	size_type index_of(const T& item, size_type index = 0) const
 	{
 		RDE_ASSERT(index >= 0 && index < size());
-		for ( ; index < size(); ++index)
+		for (; index < size(); ++index)
 			if (m_begin[index] == item)
 				return index;
 		return npos;


### PR DESCRIPTION
Added an `.editorconfig`, adhering as closely as possible to the original author's style, and applied those settings using auto format to all applicable files (excluding the `test/` dir).

Apart from line-splitting a couple of [nested template class typedefs](https://github.com/msinilo/rdestl/compare/master...StelioKontosXBL:consistent-formatting?expand=1#diff-dcce8ae4fb59c29893829e7a001dcfa1460abffc1ccca263fa766ec4056db3ddL11-R16) and adding a few missing [close-scope comments](https://github.com/msinilo/rdestl/compare/master...StelioKontosXBL:consistent-formatting?expand=1#diff-633a6d6fea63ad9b832c9278c4a60bebff7d15088f48ff65207ed8ca650f253fL52-R59) for consistency's sake, changes in this branch are all style changes - no actual code changes.