### PR TITLE
Update target platform

### DIFF
--- a/Test/rdestl-test.vcxproj
+++ b/Test/rdestl-test.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{047B2954-859C-11DC-8314-0800200C9A66}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Final|Win32'" Label="Configuration">

--- a/rdestl.vcxproj
+++ b/rdestl.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2E3C8BF2-8595-11DC-8314-0800200C9A66}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Final|Win32'" Label="Configuration">


### PR DESCRIPTION
Minimum supported platform for Github actions vm (running on Windows Server 2022) is 10.0.17763.0; the previous target platform was failing to build. See [https://github.com/actions/virtual-environments/blob/win22/20220316.1/images/win/Windows2022-Readme.md#installed-windows-sdks](https://github.com/actions/virtual-environments/blob/win22/20220316.1/images/win/Windows2022-Readme.md#installed-windows-sdks).